### PR TITLE
feat: sealer support uninstall app by image name

### DIFF
--- a/apply/applydriver/interface.go
+++ b/apply/applydriver/interface.go
@@ -18,4 +18,5 @@ type Interface interface {
 	Apply() error
 	Delete() error
 	Upgrade(imageName string) error
+	Uninstall(imageName string) error
 }

--- a/apply/applydriver/local.go
+++ b/apply/applydriver/local.go
@@ -317,3 +317,21 @@ func (c *Applier) deleteCluster() error {
 
 	return nil
 }
+
+func (c *Applier) Uninstall(imgName string) error {
+	c.ClusterDesired.Spec.Image = imgName
+	if err := c.mountClusterImage(); err != nil {
+		return err
+	}
+
+	uninstallProcessor, err := processor.NewUninstallProcessor(c.CloudImageMounter)
+	if err != nil {
+		return err
+	}
+	if err := processor.NewExecutor(uninstallProcessor).Execute(c.ClusterDesired); err != nil {
+		return err
+	}
+
+	logger.Info("Succeeded in uninstalling %s in current cluster", imgName)
+	return nil
+}

--- a/apply/processor/uninstall.go
+++ b/apply/processor/uninstall.go
@@ -1,0 +1,115 @@
+// Copyright © 2022 Alibaba Group Holding Ltu.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implieu.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/sealer/common"
+	"github.com/alibaba/sealer/pkg/filesystem/cloudimage"
+	"github.com/alibaba/sealer/pkg/runtime"
+	v2 "github.com/alibaba/sealer/types/api/v2"
+	"github.com/alibaba/sealer/utils"
+	"github.com/alibaba/sealer/utils/platform"
+	"github.com/alibaba/sealer/utils/ssh"
+	"golang.org/x/sync/errgroup"
+)
+
+type UninstallProcessor struct {
+	cloudImageMounter cloudimage.Interface
+}
+
+func (u *UninstallProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, error) {
+	var todoList []func(cluster *v2.Cluster) error
+	todoList = append(todoList,
+		u.Uninstall,
+		u.UnMountRootfs,
+		u.UnMountImage,
+	)
+	return todoList, nil
+}
+
+func (u *UninstallProcessor) Uninstall(cluster *v2.Cluster) error {
+	var (
+		rootfs = common.DefaultTheClusterRootfsDir(cluster.Name)
+		lf     = fmt.Sprintf("%s/scripts/uninstall.sh", platform.DefaultMountCloudImageDir(cluster.Name))
+		rf     = "/tmp/uninstall.sh"
+		ip     = cluster.GetMaster0IP()
+		cmd    = fmt.Sprintf("cd %s && chmod +x %s && /bin/bash -c %s", rootfs, rf, rf)
+	)
+
+	if !utils.IsExist(lf) {
+		return nil
+	}
+
+	sshClient, err := ssh.NewStdoutSSHClient(ip, cluster)
+	if err != nil {
+		return err
+	}
+
+	err = sshClient.Copy(ip, lf, rf)
+	if err != nil {
+		return err
+	}
+
+	return sshClient.CmdAsync(ip, cmd)
+}
+
+func (u *UninstallProcessor) UnMountRootfs(cluster *v2.Cluster) error {
+	var (
+		// local rootfs mounter dir
+		dir1 = common.DefaultTheClusterRootfsDir(cluster.Name)
+		// app mounter dir
+		dir2 = platform.DefaultMountCloudImageDir(cluster.Name)
+	)
+
+	deletedFile, err := utils.Sub(dir1, dir2)
+	if err != nil {
+		return err
+	}
+
+	cmd := fmt.Sprintf("rm -rf %s", strings.Join(deletedFile, " "))
+	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
+	config := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), runtime.GetMaster0Ip(cluster))
+	if utils.NotIn(config.IP, hosts) {
+		hosts = append(hosts, config.IP)
+	}
+
+	// do delete action
+	eg, _ := errgroup.WithContext(context.Background())
+	for _, IP := range hosts {
+		ip := IP
+		eg.Go(func() error {
+			sshClient, err := ssh.GetHostSSHClient(ip, cluster)
+			if err != nil {
+				return err
+			}
+			return sshClient.CmdAsync(ip, cmd)
+		})
+	}
+	return eg.Wait()
+}
+
+func (u *UninstallProcessor) UnMountImage(cluster *v2.Cluster) error {
+	return u.cloudImageMounter.UnMountImage(cluster)
+}
+
+func NewUninstallProcessor(mounter cloudimage.Interface) (Processor, error) {
+	return &UninstallProcessor{
+		cloudImageMounter: mounter,
+	}, nil
+}

--- a/sealer/cmd/uninstall.go
+++ b/sealer/cmd/uninstall.go
@@ -1,0 +1,64 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alibaba/sealer/pkg/clusterfile"
+
+	"github.com/alibaba/sealer/apply"
+	"github.com/spf13/cobra"
+)
+
+var uninstallClusterName string
+
+// uninstallCmd represents the upgrade command
+var uninstallCmd = &cobra.Command{
+	Use:     "uninstall",
+	Short:   "uninstall your app installed by sealer",
+	Long:    `sealer uninstall imagename --cluster clustername`,
+	Example: `sealer uninstall dashboard:v1`,
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		//get cluster name
+		if uninstallClusterName == "" {
+			uninstallClusterName, err = clusterfile.GetDefaultClusterName()
+			if err != nil {
+				return err
+			}
+		}
+		//get Clusterfile
+		userHome, _ := os.UserHomeDir()
+
+		desiredCluster, err := clusterfile.GetClusterFromFile(fmt.Sprintf(clusterfilepath, userHome, uninstallClusterName))
+		if err != nil {
+			return err
+		}
+
+		applier, err := apply.NewApplier(desiredCluster)
+		if err != nil {
+			return err
+		}
+		return applier.Uninstall(args[0])
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(uninstallCmd)
+	uninstallCmd.Flags().StringVarP(&uninstallClusterName, "cluster", "c", "", "The name of your cluster to uninstall")
+}

--- a/utils/directory.go
+++ b/utils/directory.go
@@ -1,0 +1,91 @@
+// Copyright © 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Sub(dir1, dir2 string) ([]string, error) {
+	var deleted []string
+	isSame, err := IsSameDir(dir1, dir2)
+	if err != nil {
+		return nil, err
+	}
+	if isSame {
+		deleted = append(deleted, dir1)
+		return deleted, nil
+	}
+
+	contents, err := ioutil.ReadDir(dir1)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range contents {
+		if !IsExist(filepath.Join(dir2, file.Name())) {
+			continue
+		}
+
+		if file.IsDir() {
+			data, err := Sub(filepath.Join(dir1, file.Name()), filepath.Join(dir2, file.Name()))
+			if err != nil {
+				return nil, err
+			}
+			deleted = append(deleted, data...)
+		} else {
+			deleted = append(deleted, filepath.Join(dir1, file.Name()))
+		}
+	}
+	return deleted, nil
+}
+
+func IsSameDir(dir1, dir2 string) (bool, error) {
+	list1, err := getFileList(dir1)
+	if err != nil {
+		return false, err
+	}
+
+	list2, err := getFileList(dir2)
+	if err != nil {
+		return false, err
+	}
+	add, sub := GetDiffHosts(list1, list2)
+	if len(add) == 0 && len(sub) == 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func getFileList(path string) ([]string, error) {
+	var directory []string
+	var err error
+
+	walkFn := func(currPath string, info os.FileInfo, err error) error {
+		newContent := strings.TrimPrefix(currPath, path)
+		if newContent != "" {
+			directory = append(directory, newContent)
+		}
+		return nil
+	}
+
+	err = filepath.Walk(path, walkFn)
+
+	return directory, err
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

uninstall process workflow:

0. mount app image locally and scp the related uninstall scripts to master0.
1. exec scripts/uninstall.sh under $rootfs dir on master0 machine.
2. delete app image files in $rootfs dir on each cluster node. Including build context and container image.

### Describe how to verify it

kubefile:

```shell
FROM kubernetes:v1.20.4
COPY uninstall.sh scripts
COPY dashboard.yaml manifests
CMD kubectl apply -f manifests/dashboard.yaml
```

cat uninstall.sh

```shell
kubectl delete -f manifests/dashboard.yaml
```

build app image , run and uninstall app image.

```shell
sealer build -t dashboard:v1 --base=false
sealer run dashboard:v1
sealer uninstall dashboard:v1
```
### Special notes for reviews
