### PR TITLE
cmd: polish cmd discription to add user readablity

### DIFF
--- a/cmd/sealer/cmd/apply.go
+++ b/cmd/sealer/cmd/apply.go
@@ -25,8 +25,11 @@ var clusterFile string
 
 // applyCmd represents the apply command
 var applyCmd = &cobra.Command{
-	Use:     "apply",
-	Short:   "apply a kubernetes cluster",
+	Use:   "apply",
+	Short: "apply a Kubernetes cluster via specified Clusterfile",
+	Long: `apply command is used to apply a Kubernetes cluster via specified Clusterfile.
+If the Clusterfile is applied first time, Kubernetes cluster will be created. Otherwise, sealer
+will apply the diff change of current Clusterfile and the original one.`,
 	Example: `sealer apply -f Clusterfile`,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,6 +43,6 @@ var applyCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(applyCmd)
-	applyCmd.Flags().StringVarP(&clusterFile, "Clusterfile", "f", "Clusterfile", "apply a kubernetes cluster")
-	applyCmd.Flags().BoolVar(&runtime.ForceDelete, "force", false, "We also can input an --force flag to delete cluster by force")
+	applyCmd.Flags().StringVarP(&clusterFile, "Clusterfile", "f", "Clusterfile", "Clusterfile path to apply a Kubernetes cluster")
+	applyCmd.Flags().BoolVar(&runtime.ForceDelete, "force", false, "force to delete the specified cluster if set true")
 }

--- a/cmd/sealer/cmd/build.go
+++ b/cmd/sealer/cmd/build.go
@@ -40,8 +40,11 @@ var buildConfig *BuildFlag
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use:   "build [flags] PATH",
-	Short: "build an cloud image from a Kubefile",
-	Long:  "sealer build -f Kubefile -t my-kubernetes:1.19.8 [--base=false] [--no-cache]",
+	Short: "build a CloudImage from a Kubefile",
+	Long: `build command is used to build a CloudImage from specified Kubefile.
+It organizes the specified Kubefile and input building context, and builds
+a brand new CloudImage.`,
+	Args: cobra.ExactArgs(1),
 	Example: `the current path is the context path, default build type is lite and use build cache
 
 build:
@@ -55,15 +58,9 @@ build without base:
 
 build with args:
 	sealer build -f Kubefile -t my-kubernetes:1.19.8 --build-arg MY_ARG=abc,PASSWORD=Sealer123 .
-
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var (
-			buildContext = "."
-		)
-		if len(args) != 0 {
-			buildContext = args[0]
-		}
+		buildContext := args[0]
 
 		targetPlatforms, err := platform.GetPlatform(buildConfig.Platform)
 		if err != nil {
@@ -95,13 +92,13 @@ build with args:
 func init() {
 	buildConfig = &BuildFlag{}
 	rootCmd.AddCommand(buildCmd)
-	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "cluster image build type, default is lite")
-	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "kubefile filepath")
-	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "cluster image name")
+	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "CloudImage build type, default is lite")
+	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "Kubefile filepath")
+	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "the name of CloudImage")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
-	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image,default value is true.")
+	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image, default value is true.")
 	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build args")
-	buildCmd.Flags().StringVar(&buildConfig.Platform, "platform", "", "set cloud image platform,if not set,keep same platform with runtime")
+	buildCmd.Flags().StringVar(&buildConfig.Platform, "platform", "", "set CloudImage platform. If not set, keep same platform with runtime")
 
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logger.Error("failed to init flag: %v", err)

--- a/cmd/sealer/cmd/cert.go
+++ b/cmd/sealer/cmd/cert.go
@@ -30,18 +30,18 @@ var altNames string
 // certCmd represents the cert command
 var certCmd = &cobra.Command{
 	Use:   "cert",
-	Short: "update k8s API server cert",
+	Short: "update Kubernetes API server's cert",
 	Long: `Add domain or ip in certs:
-    you better to backup your old certs first
+    you had better backup old certs first.
 	sealer cert --alt-names sealer.cool,10.103.97.2,127.0.0.1,localhost
     using "openssl x509 -noout -text -in apiserver.crt" to check the cert
-	will update cluster API server cert, you need restart your API server manually after using sealer cert
+	will update cluster API server cert, you need to restart your API server manually after using sealer cert.
 
-    For example: add a EIP to cert.
+    For example: add an EIP to cert.
     1. sealer cert --alt-names 39.105.169.253
     2. update the kubeconfig, cp /etc/kubernetes/admin.conf .kube/config
     3. edit .kube/config, set the apiserver address as 39.105.169.253, (don't forget to open the security group port for 6443, if you using public cloud)
-    4. kubectl get pod, to check it works or not
+    4. kubectl get pod, to check if it works or not
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := clusterfile.GetDefaultCluster()

--- a/cmd/sealer/cmd/check.go
+++ b/cmd/sealer/cmd/check.go
@@ -31,8 +31,10 @@ var checkArgs *CheckArgs
 
 // pushCmd represents the push command
 var checkCmd = &cobra.Command{
-	Use:     "check",
-	Short:   "check the state of cluster ",
+	Use:   "check",
+	Short: "check the state of cluster",
+	Long: `check command is used to check status of the cluster, including node status
+, service status and pod status.`,
 	Example: `sealer check --pre or sealer check --post`,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/debug.go
+++ b/cmd/sealer/cmd/debug.go
@@ -25,6 +25,8 @@ var debugOptions = debug.NewDebugOptions()
 var debugCommand = &cobra.Command{
 	Use:   "debug",
 	Short: "Create debugging sessions for pods and nodes",
+	// TODO: add long description.
+	Long: "",
 }
 
 func init() {
@@ -38,7 +40,7 @@ func init() {
 	debugCommand.PersistentFlags().StringVar(&debugOptions.Image, "image", debugOptions.Image, "Container image to use for debug container.")
 	debugCommand.PersistentFlags().StringVar(&debugOptions.DebugContainerName, "name", debugOptions.DebugContainerName, "Container name to use for debug container.")
 	debugCommand.PersistentFlags().StringVar(&debugOptions.PullPolicy, "image-pull-policy", "IfNotPresent", "Container image pull policy, default policy is IfNotPresent.")
-	debugCommand.PersistentFlags().StringSliceVar(&debugOptions.CheckList, "check-list", debugOptions.CheckList, "Check items, such as network、volume.")
+	debugCommand.PersistentFlags().StringSliceVar(&debugOptions.CheckList, "check-list", debugOptions.CheckList, "Check items, such as network, volume.")
 	debugCommand.PersistentFlags().StringVarP(&debugOptions.Namespace, "namespace", "n", "default", "Namespace of Pod.")
 	debugCommand.PersistentFlags().BoolVarP(&debugOptions.Interactive, "stdin", "i", debugOptions.Interactive, "Keep stdin open on the container, even if nothing is attached.")
 	debugCommand.PersistentFlags().BoolVarP(&debugOptions.TTY, "tty", "t", debugOptions.TTY, "Allocate a TTY for the debugging container.")

--- a/cmd/sealer/cmd/delete.go
+++ b/cmd/sealer/cmd/delete.go
@@ -34,11 +34,12 @@ var (
 // deleteCmd represents the delete command
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "delete a cluster",
-	Long:  `if provider is Bare Metal Server will delete kubernetes nodes`,
-	Args:  cobra.NoArgs,
+	Short: "delete an existing cluster",
+	Long: `delete command is used to delete part or all of existing cluster.
+User can delete cluster by explicitly specifying node IP, Clusterfile, or cluster name.`,
+	Args: cobra.NoArgs,
 	Example: `
-delete to default cluster: 
+delete default cluster: 
 	sealer delete --masters x.x.x.x --nodes x.x.x.x
 	sealer delete --masters x.x.x.x-x.x.x.y --nodes x.x.x.x-x.x.x.y
 delete all:

--- a/cmd/sealer/cmd/exec.go
+++ b/cmd/sealer/cmd/exec.go
@@ -25,7 +25,9 @@ var roles string
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
 	Use:   "exec",
-	Short: "exec a shell command or script on all node.",
+	Short: "exec a shell command or script on specified nodes.",
+	// TODO: add long description.
+	Long: "",
 	Example: `
 exec to default cluster: my-cluster
 	sealer exec "cat /etc/hosts"
@@ -46,6 +48,6 @@ set role label to exec cmd:
 
 func init() {
 	rootCmd.AddCommand(execCmd)
-	execCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "submit one cluster name")
+	execCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "specify the name of cluster")
 	execCmd.Flags().StringVarP(&roles, "roles", "r", "", "set role label to roles")
 }

--- a/cmd/sealer/cmd/gen.go
+++ b/cmd/sealer/cmd/gen.go
@@ -30,7 +30,7 @@ var flag *processor.ParserArg
 // genCmd represents the gen command
 var genCmd = &cobra.Command{
 	Use:   "gen",
-	Short: "Generate a Clusterfile to take over a normal cluster which not deployed by sealer",
+	Short: "generate a Clusterfile to take over a normal cluster which is not deployed by sealer",
 	Long: `sealer gen --passwd xxxx --image kubernetes:v1.19.8
 
 The takeover actually is to generate a Clusterfile by kubeconfig.
@@ -73,7 +73,7 @@ func init() {
 	genCmd.Flags().Uint16Var(&flag.Port, "port", 22, "set the sshd service port number for the server (default port: 22)")
 	genCmd.Flags().StringVar(&flag.Pk, "pk", cert.GetUserHomeDir()+"/.ssh/id_rsa", "set server private key")
 	genCmd.Flags().StringVar(&flag.PkPassword, "pk-passwd", "", "set server private key password")
-	genCmd.Flags().StringVar(&flag.Image, "image", "", "Set taken over cloud image")
+	genCmd.Flags().StringVar(&flag.Image, "image", "", "Set taken over CloudImage")
 	genCmd.Flags().StringVar(&flag.Name, "name", "default", "Set taken over cluster name")
 	genCmd.Flags().StringVar(&flag.Passwd, "passwd", "", "Set taken over ssh passwd")
 }

--- a/cmd/sealer/cmd/images.go
+++ b/cmd/sealer/cmd/images.go
@@ -38,8 +38,10 @@ const (
 )
 
 var listCmd = &cobra.Command{
-	Use:     "images",
-	Short:   "list all cluster images",
+	Use:   "images",
+	Short: "list all CloudImages on the local node",
+	// TODO: add long description.
+	Long:    "",
 	Args:    cobra.NoArgs,
 	Example: `sealer images`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/inspect.go
+++ b/cmd/sealer/cmd/inspect.go
@@ -29,7 +29,7 @@ var inspectPlatformFlag string
 // inspectCmd represents the inspect command
 var inspectCmd = &cobra.Command{
 	Use:   "inspect",
-	Short: "print the image information or clusterFile",
+	Short: "print the image information or Clusterfile",
 	Long:  `sealer inspect ${image id} to print image information`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -52,5 +52,5 @@ var inspectCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(inspectCmd)
-	inspectCmd.Flags().StringVar(&inspectPlatformFlag, "platform", "", "set cloud image platform")
+	inspectCmd.Flags().StringVar(&inspectPlatformFlag, "platform", "", "set CloudImage platform")
 }

--- a/cmd/sealer/cmd/join.go
+++ b/cmd/sealer/cmd/join.go
@@ -27,10 +27,12 @@ var joinArgs *apply.Args
 
 var joinCmd = &cobra.Command{
 	Use:   "join",
-	Short: "join node to cluster",
-	Args:  cobra.NoArgs,
+	Short: "join new master or worker node to specified cluster",
+	// TODO: add long description.
+	Long: "",
+	Args: cobra.NoArgs,
 	Example: `
-join to default cluster:
+join default cluster:
 	sealer join --masters x.x.x.x --nodes x.x.x.x
     sealer join --masters x.x.x.x-x.x.x.y --nodes x.x.x.x-x.x.x.y
 `,
@@ -56,5 +58,5 @@ func init() {
 	rootCmd.AddCommand(joinCmd)
 	joinCmd.Flags().StringVarP(&joinArgs.Masters, "masters", "m", "", "set Count or IPList to masters")
 	joinCmd.Flags().StringVarP(&joinArgs.Nodes, "nodes", "n", "", "set Count or IPList to nodes")
-	joinCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "submit one cluster name")
+	joinCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "specify the name of cluster")
 }

--- a/cmd/sealer/cmd/load.go
+++ b/cmd/sealer/cmd/load.go
@@ -29,8 +29,8 @@ var imageSrc string
 // loadCmd represents the load command
 var loadCmd = &cobra.Command{
 	Use:     "load",
-	Short:   "load image from a tar file",
-	Long:    `Load an image from a tar archive`,
+	Short:   "load a CloudImage from a tar file",
+	Long:    `Load a CloudImage from a tar archive`,
 	Example: `sealer load -i kubernetes.tar`,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/login.go
+++ b/cmd/sealer/cmd/login.go
@@ -32,8 +32,10 @@ type LoginFlag struct {
 var loginConfig *LoginFlag
 
 var loginCmd = &cobra.Command{
-	Use:     "login",
-	Short:   "login image repository",
+	Use:   "login",
+	Short: "login image registry",
+	// TODO: add long description.
+	Long:    "",
 	Example: `sealer login registry.cn-qingdao.aliyuncs.com -u [username] -p [password]`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/merge.go
+++ b/cmd/sealer/cmd/merge.go
@@ -46,7 +46,7 @@ merge images:
 	}
 	mf = &mergeFlag{}
 	mergeCmd.Flags().StringVarP(&mf.ImageName, "target-image", "t", "", "target image name")
-	mergeCmd.Flags().StringVar(&mf.Platform, "platform", "", "set cloud image platform,if not set,keep same platform with runtime")
+	mergeCmd.Flags().StringVar(&mf.Platform, "platform", "", "set CloudImage platform, if not set,keep same platform with runtime")
 
 	if err := mergeCmd.MarkFlagRequired("target-image"); err != nil {
 		logger.Error("failed to init flag target image: %v", err)

--- a/cmd/sealer/cmd/prune.go
+++ b/cmd/sealer/cmd/prune.go
@@ -25,10 +25,16 @@ import (
 )
 
 var pruneCmd = &cobra.Command{
-	Use:     "prune",
-	Short:   "prune sealer data dir",
-	Args:    cobra.NoArgs,
-	Example: `sealer prune`,
+	Use:   "prune",
+	Short: "prune sealer data dir",
+	// TODO: add long description.
+	Long: "",
+	Args: cobra.NoArgs,
+	Example: `$ sealer prune
+start to prune image db ...
+start to prune layer ...
+start to prune build tmp ...
+`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		buildTmp := prune.NewBuildPrune()
 		ima, err := prune.NewImagePrune()

--- a/cmd/sealer/cmd/pull.go
+++ b/cmd/sealer/cmd/pull.go
@@ -26,8 +26,10 @@ var platformFlag string
 
 // pullCmd represents the pull command
 var pullCmd = &cobra.Command{
-	Use:     "pull",
-	Short:   "pull cloud image to local",
+	Use:   "pull",
+	Short: "pull CloudImage from a registry to local",
+	// TODO: add long description.
+	Long:    "",
 	Example: `sealer pull registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,5 +52,5 @@ var pullCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(pullCmd)
-	pullCmd.Flags().StringVar(&platformFlag, "platform", "", "set cloud image platform")
+	pullCmd.Flags().StringVar(&platformFlag, "platform", "", "set CloudImage platform")
 }

--- a/cmd/sealer/cmd/push.go
+++ b/cmd/sealer/cmd/push.go
@@ -23,8 +23,10 @@ import (
 
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
-	Use:     "push",
-	Short:   "push cloud image to registry",
+	Use:   "push",
+	Short: "push CloudImage to remote registry",
+	// TODO: add long description.
+	Long:    "",
 	Example: `sealer push registry.cn-qingdao.aliyuncs.com/sealer-io/my-kubernetes-cluster-with-dashboard:latest`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/rmi.go
+++ b/cmd/sealer/cmd/rmi.go
@@ -34,8 +34,10 @@ var opts removeImageFlag
 
 // rmiCmd represents the rmi command
 var rmiCmd = &cobra.Command{
-	Use:     "rmi",
-	Short:   "remove local images by name",
+	Use:   "rmi",
+	Short: "remove local images by name",
+	// TODO: add long description.
+	Long:    "",
 	Example: `sealer rmi registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8`,
 	Args:    cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -76,5 +78,5 @@ func runRemove(images []string) error {
 func init() {
 	opts = removeImageFlag{}
 	rootCmd.AddCommand(rmiCmd)
-	rmiCmd.Flags().StringVar(&opts.platform, "platform", "", "set cloud image platform")
+	rmiCmd.Flags().StringVar(&opts.platform, "platform", "", "set CloudImage platform")
 }

--- a/cmd/sealer/cmd/root.go
+++ b/cmd/sealer/cmd/root.go
@@ -40,8 +40,9 @@ var rootOpt rootOpts
 var rootCmd = &cobra.Command{
 	Use:   "sealer",
 	Short: "A tool to build, share and run any distributed applications.",
-	Long: `sealer is a tool to seal application's all dependencies and Kubernetes into CloudImage,
-distribute this application anywhere via CloudImage, and run it within any cluster in one command.
+	Long: `sealer is a tool to seal application's all dependencies and Kubernetes
+into CloudImage by Kubefile, distribute this application anywhere via CloudImage, 
+and run it within any cluster with Clusterfile in one command.
 `,
 }
 

--- a/cmd/sealer/cmd/run.go
+++ b/cmd/sealer/cmd/run.go
@@ -30,7 +30,7 @@ var runArgs *apply.Args
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "run a cluster with images and arguments",
+	Short: "start to run a cluster from a CloudImage",
 	Long:  `sealer run registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8 --masters [arg] --nodes [arg]`,
 	Example: `
 create cluster to your bare metal server, appoint the iplist:
@@ -64,8 +64,8 @@ func init() {
 	runArgs = &apply.Args{}
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringVarP(&runArgs.Provider, "provider", "", "", "set infra provider, example `ALI_CLOUD`, the local server need ignore this")
-	runCmd.Flags().StringVarP(&runArgs.Masters, "masters", "m", "", "set Count or IPList to masters")
-	runCmd.Flags().StringVarP(&runArgs.Nodes, "nodes", "n", "", "set Count or IPList to nodes")
+	runCmd.Flags().StringVarP(&runArgs.Masters, "masters", "m", "", "set count or IPList to masters")
+	runCmd.Flags().StringVarP(&runArgs.Nodes, "nodes", "n", "", "set count or IPList to nodes")
 	runCmd.Flags().StringVar(&runArgs.ClusterName, "cluster-name", "my-cluster", "set cluster name")
 	runCmd.Flags().StringVarP(&runArgs.User, "user", "u", "root", "set baremetal server username")
 	runCmd.Flags().StringVarP(&runArgs.Password, "passwd", "p", "", "set cloud provider or baremetal server password")

--- a/cmd/sealer/cmd/save.go
+++ b/cmd/sealer/cmd/save.go
@@ -38,7 +38,7 @@ var save saveFlag
 // saveCmd represents the save command
 var saveCmd = &cobra.Command{
 	Use:   "save",
-	Short: "save image to a tar file",
+	Short: "save CloudImage to a tar file",
 	Long:  `sealer save -o [output file name] [image name]`,
 	Example: `
 save kubernetes:v1.19.8 image to kubernetes.tar file:
@@ -94,7 +94,7 @@ func init() {
 	rootCmd.AddCommand(saveCmd)
 	save = saveFlag{}
 	saveCmd.Flags().StringVarP(&save.ImageTar, "output", "o", "", "write the image to a file")
-	saveCmd.Flags().StringVar(&save.Platform, "platform", "", "set cloud image platform")
+	saveCmd.Flags().StringVar(&save.Platform, "platform", "", "set CloudImage platform")
 
 	if err := saveCmd.MarkFlagRequired("output"); err != nil {
 		logger.Error("failed to init flag: %v", err)

--- a/cmd/sealer/cmd/search.go
+++ b/cmd/sealer/cmd/search.go
@@ -30,12 +30,14 @@ import (
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "sealer search kubernetes",
-	Example: `
-sealer search <imageDomain>/<imageRepo>/<imageName> ...
+	Short: "search CloudImage in default registry",
+	// TODO: add long description.
+	Long: "",
+	Example: `sealer search <imageDomain>/<imageRepo>/<imageName> ...
 ## default imageDomain: 'registry.cn-qingdao.aliyuncs.com', default imageRepo: 'sealer-io'
 ex.:
-  sealer search kubernetes seadent/rootfs docker.io/library/hello-world`,
+  sealer search kubernetes seadent/rootfs docker.io/library/hello-world
+`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/sealer/cmd/tag.go
+++ b/cmd/sealer/cmd/tag.go
@@ -21,8 +21,10 @@ import (
 )
 
 var tagCmd = &cobra.Command{
-	Use:     "tag",
-	Short:   "tag a image as a new one",
+	Use:   "tag",
+	Short: "create a new tag that refers to a local CloudImage",
+	// TODO: add long description.
+	Long:    "",
 	Example: `sealer tag kubernetes:v1.19.8 registry.cn-qingdao.aliyuncs.com/sealer-apps/kubernetes:v1.19.8`,
 	Args:    cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/upgrade.go
+++ b/cmd/sealer/cmd/upgrade.go
@@ -33,8 +33,8 @@ const (
 // upgradeCmd represents the upgrade command
 var upgradeCmd = &cobra.Command{
 	Use:     "upgrade",
-	Short:   "upgrade your kubernetes cluster",
-	Long:    `sealer upgrade image name --cluster cluster name`,
+	Short:   "upgrade specified Kubernetes cluster",
+	Long:    `sealer upgrade imagename --cluster clustername`,
 	Example: `sealer upgrade kubernetes:v1.19.9 --cluster my-cluster`,
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,5 +63,5 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
-	upgradeCmd.Flags().StringVarP(&upgradeClusterName, "cluster", "c", "", "The name of your cluster to upgrade")
+	upgradeCmd.Flags().StringVarP(&upgradeClusterName, "cluster", "c", "", "the name of cluster")
 }

--- a/cmd/sealer/cmd/version.go
+++ b/cmd/sealer/cmd/version.go
@@ -27,7 +27,7 @@ var shortPrint bool
 
 var versionCmd = &cobra.Command{
 	Use:     "version",
-	Short:   "show sealer version",
+	Short:   "show sealer and related versions",
 	Args:    cobra.NoArgs,
 	Example: `sealer version`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -47,5 +47,5 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	versionCmd.Flags().BoolVar(&shortPrint, "short", false, "If true, print just the version number.")
+	versionCmd.Flags().BoolVar(&shortPrint, "short", false, "if true, print sealer's own version number.")
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

### Describe what this PR does / why we need it

Currently, the seal command usage may be not so explicit. This pull request tries to polish the command description and introduce more readability.

In addition, this pull request use the unique key word `CloudImage`. CloudImage, Kubefile, Clusterfile is the reserved word of sealer project. We should maintain these for brand.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
none