### PR TITLE
optimize automated build actions, optimize scripts

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -17,8 +17,17 @@ jobs:
         run: |
           commentbody="${{github.event.comment.body}}"
           version=`echo "$commentbody"|cut -d" " -f2`
-          echo "start to build kubernetes:$version"
-          sudo wget https://sealer.oss-cn-beijing.aliyuncs.com/auto-build/context.tar.gz && sudo tar -zxf context.tar.gz && cd context
+          cri=`echo "$commentbody"|cut -d" " -f3`
+          ##default cri is docker
+          cri=`[[ ! -z "$cri" ]] && echo "$cri" || echo docker`
+          ##gt || eq v1.24.0 cri must be containerd
+          version_compare() { printf '%s\n%s\n' "$2" "$1" | sort -V -C; } ## version_vompare $versionA $versionB:  $versionA>=$versionB
+          cri=`version_compare "$version" "v1.24.0" && echo "containerd" || echo $cri` # v1.24.0 and above remove dockershim, so use containerd
+          cridir=${cri}Rootfs
+          kubeadmApiVersion=`(version_compare "$version" "v1.23.0" && echo 'kubeadm.k8s.io\/v1beta3') || (version_compare "$version" "v1.15.0" && echo 'kubeadm.k8s.io\/v1beta2') || (version_compare "$version" "v1.13.0" && echo 'kubeadm.k8s.io\/v1beta1')`
+          echo "start to build kubernetes:$version cri: $cri"
+          ## nerdctl version: 0.19.0; cri-containerd version: 1.6.4;
+          sudo wget https://sealer.oss-cn-beijing.aliyuncs.com/auto-build/cri-context.tar.gz && sudo tar -zxf cri-context.tar.gz && cd context
           #amd64
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/amd64/kubectl -o ./amd64/bin/kubectl
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/amd64/kubelet -o ./amd64/bin/kubelet
@@ -27,21 +36,30 @@ jobs:
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/arm64/kubectl -o ./arm64/bin/kubectl
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/arm64/kubelet -o ./arm64/bin/kubelet
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/arm64/kubeadm -o ./arm64/bin/kubeadm
+          sudo chmod +x amd64/bin/kube* && sudo chmod +x arm64/bin/kube*
           sudo wget https://sealer.oss-cn-beijing.aliyuncs.com/sealer-latest.tar.gz && sudo tar -xvf sealer-latest.tar.gz -C /usr/bin
           sudo sealer login ${{secrets.PRIVATEWAREHOUSE}}
-          sudo sed -i "s/v1.19.8/$version/g" ./rootfs/etc/kubeadm.yml && sudo sed -i "s/v1.19.8/$version/g" ./calico/Kubefile
-          sudo chmod +x ./amd64/bin/kubeadm && sudo ./amd64/bin/kubeadm config images list --config ./rootfs/etc/kubeadm.yml
-          sudo ./amd64/bin/kubeadm config images list --config ./rootfs/etc/kubeadm.yml 2>/dev/null>> imageList
-          if [ $(sudo ./amd64/bin/kubeadm config images list --config ./rootfs/etc/kubeadm.yml 2>/dev/null |grep -c "coredns/coredns") -gt 0 ]; then sudo sed -i "s/#imageRepository/imageRepository/g" ./rootfs/etc/kubeadm.yml; fi
-          sudo sed -i "s/k8s.gcr.io/sea.hub:5000/g" ./rootfs/etc/kubeadm.yml
-          sudo sealer build -t kubernetes:$version-alpine --platform linux/arm64,linux/amd64
-          sudo sealer push kubernetes:$version-alpine
-          cd calico && sudo sealer build -t kubernetes:$version --platform linux/arm64,linux/amd64
-          sudo sealer push kubernetes:$version
-          echo "::set-output name=version::$version"
+          sudo sed -i "s/v1.19.8/$version/g" ${cridir}/rootfs/etc/kubeadm.yml ##change version
+          sudo sed -i "s/kubeadm.k8s.io\/v1beta2/$kubeadmApiVersion/g" ${cridir}/rootfs/etc/kubeadm.yml
+          sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml
+          sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml 2>/dev/null>> imageList
+          if [ $(sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml 2>/dev/null |grep -c "coredns/coredns") -gt 0 ]; then sudo sed -i "s/#imageRepository/imageRepository/g" $cridir/rootfs/etc/kubeadm.yml; fi
+          sudo sed -i "s/k8s.gcr.io/sea.hub:5000/g" $cridir/rootfs/etc/kubeadm.yml
+          sudo sed -i "s/sea.hub:5000\/pause:3.6/$(grep pause imageList |sed 's/\//\\\//g')/g" containerdRootfs/rootfs/etc/dump-config.toml
+          sudo cp -r $cridir/* .
+          buildName=registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes
+          if [[ "$cri" = "containerd" ]]; then buildName=${buildName}-containerd;fi
+          sudo sealer build -t ${buildName}:${version}-alpine -f Kubefile --platform linux/arm64,linux/amd64 .
+          sudo sealer push $buildName:${version}-alpine
+          sudo sed -i "/FROM/d" calico/Kubefile && sudo echo "FROM ${buildName}:${version}-alpine
+          `cat calico/Kubefile`" > calico/Kubefile
+          cd calico && sudo sealer build -t ${buildName}:${version} -f Kubefile --platform linux/arm64,linux/amd64 .
+          sudo sealer push ${buildName}:${version}
+          echo "::set-output name=version::${buildName}:${version}"
       - name: Success Commit
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
             Image ${{ steps.autobuild.outputs.version }} build successfully!
+            without calico cni image: ${{ steps.autobuild.outputs.version }}-alpine.

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -17,17 +17,19 @@ jobs:
         run: |
           commentbody="${{github.event.comment.body}}"
           version=`echo "$commentbody"|cut -d" " -f2`
-          cri=`echo "$commentbody"|cut -d" " -f3`
-          ##default cri is docker
-          cri=`[[ ! -z "$cri" ]] && echo "$cri" || echo docker`
           ##gt || eq v1.24.0 cri must be containerd
-          version_compare() { printf '%s\n%s\n' "$2" "$1" | sort -V -C; } ## version_vompare $versionA $versionB:  $versionA>=$versionB
-          cri=`version_compare "$version" "v1.24.0" && echo "containerd" || echo $cri` # v1.24.0 and above remove dockershim, so use containerd
+          version_compare() { printf '%s\n%s\n' "$2" "$1" | sort -V -C; } ## version_vompare $a $b:  a>=b
+          cri=`echo "$commentbody"|cut -d" " -f3`
+          ##[v1.20.x-1.24.0): default cri use docker; (*-v1.20.0): cri use docker; [v1.24.0-*): cri use containerd
+          cri=`[[ ! -z "$cri" ]] && echo "$cri" || echo docker`
+          cri=`version_compare "$version" "v1.24.0" && echo "containerd" || echo $cri`
           cridir=${cri}Rootfs
           kubeadmApiVersion=`(version_compare "$version" "v1.23.0" && echo 'kubeadm.k8s.io\/v1beta3') || (version_compare "$version" "v1.15.0" && echo 'kubeadm.k8s.io\/v1beta2') || (version_compare "$version" "v1.13.0" && echo 'kubeadm.k8s.io\/v1beta1')`
           echo "start to build kubernetes:$version cri: $cri"
-          ## nerdctl version: 0.19.0; cri-containerd version: 1.6.4;
+          ## nerdctl: 0.19.0; cri-containerd: 1.6.4;
           sudo wget https://sealer.oss-cn-beijing.aliyuncs.com/auto-build/cri-context.tar.gz && sudo tar -zxf cri-context.tar.gz && cd context
+          sudo wget https://sealer.oss-cn-beijing.aliyuncs.com/auto-build/${cri}-context.tar.gz && sudo tar -zxf ${cri}-context.tar.gz
+
           #amd64
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/amd64/kubectl -o ./amd64/bin/kubectl
           sudo curl -L https://dl.k8s.io/release/$version/bin/linux/amd64/kubelet -o ./amd64/bin/kubelet
@@ -41,21 +43,22 @@ jobs:
           sudo sealer login ${{secrets.PRIVATEWAREHOUSE}}
           sudo sed -i "s/v1.19.8/$version/g" ${cridir}/rootfs/etc/kubeadm.yml ##change version
           sudo sed -i "s/kubeadm.k8s.io\/v1beta2/$kubeadmApiVersion/g" ${cridir}/rootfs/etc/kubeadm.yml
-          sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml
-          sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml 2>/dev/null>> imageList
-          if [ $(sudo ./amd64/bin/kubeadm config images list --config $cridir/rootfs/etc/kubeadm.yml 2>/dev/null |grep -c "coredns/coredns") -gt 0 ]; then sudo sed -i "s/#imageRepository/imageRepository/g" $cridir/rootfs/etc/kubeadm.yml; fi
-          sudo sed -i "s/k8s.gcr.io/sea.hub:5000/g" $cridir/rootfs/etc/kubeadm.yml
-          sudo sed -i "s/sea.hub:5000\/pause:3.6/$(grep pause imageList |sed 's/\//\\\//g')/g" containerdRootfs/rootfs/etc/dump-config.toml
+          sudo ./amd64/bin/kubeadm config images list --config ${cridir}/rootfs/etc/kubeadm.yml
+          sudo ./amd64/bin/kubeadm config images list --config ${cridir}/rootfs/etc/kubeadm.yml 2>/dev/null>> imageList
+          if [ $(sudo ./amd64/bin/kubeadm config images list --config ${cridir}/rootfs/etc/kubeadm.yml 2>/dev/null |grep -c "coredns/coredns") -gt 0 ]; then sudo sed -i "s/#imageRepository/imageRepository/g" ${cridir}/rootfs/etc/kubeadm.yml; fi
+          sudo sed -i "s/k8s.gcr.io/sea.hub:5000/g" ${cridir}/rootfs/etc/kubeadm.yml
+          if [ -f "${cridir}/rootfs/etc/dump-config.toml" ]; then sudo sed -i "s/sea.hub:5000\/pause:3.6/$(grep pause imageList |sed 's/\//\\\//g')/g" ${cridir}/rootfs/etc/dump-config.toml; fi
           sudo cp -r $cridir/* .
           buildName=registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes
-          if [[ "$cri" = "containerd" ]]; then buildName=${buildName}-containerd;fi
+          if [[ "$cri" = "containerd" ]] && ! version_compare "$version" "v1.24.0"; then buildName=${buildName}-containerd;fi
           sudo sealer build -t ${buildName}:${version}-alpine -f Kubefile --platform linux/arm64,linux/amd64 .
-          sudo sealer push $buildName:${version}-alpine
+          sudo sealer push ${buildName}:${version}-alpine
           sudo sed -i "/FROM/d" calico/Kubefile && sudo echo "FROM ${buildName}:${version}-alpine
           `cat calico/Kubefile`" > calico/Kubefile
           cd calico && sudo sealer build -t ${buildName}:${version} -f Kubefile --platform linux/arm64,linux/amd64 .
           sudo sealer push ${buildName}:${version}
           echo "::set-output name=version::${buildName}:${version}"
+          echo "::set-output name=cri::${cri}"
       - name: Success Commit
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -63,3 +66,4 @@ jobs:
           body: |
             Image ${{ steps.autobuild.outputs.version }} build successfully!
             without calico cni image: ${{ steps.autobuild.outputs.version }}-alpine.
+            CRI use ${{ steps.autobuild.outputs.cri }}.

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -147,7 +147,7 @@ func (k *KubeadmRuntime) DeleteRegistry() error {
 		return fmt.Errorf("failed to delete registry: %v", err)
 	}
 
-	cmd := fmt.Sprintf("if docker inspect %s;then docker rm -f %[1]s;fi && (! nerdctl ps -a |grep %[1]s || nerdctl rmi -f %[1]s)", RegistryName)
+	cmd := fmt.Sprintf("if docker inspect %s;then docker rm -f %[1]s;fi && (! nerdctl ps -a |grep %[1]s || nerdctl stop %[1]s && nerdctl rmi -f %[1]s)", RegistryName)
 	return ssh.CmdAsync(k.RegConfig.IP, cmd)
 }
 

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -147,7 +147,7 @@ func (k *KubeadmRuntime) DeleteRegistry() error {
 		return fmt.Errorf("failed to delete registry: %v", err)
 	}
 
-	cmd := fmt.Sprintf("if docker inspect %s;then docker rm -f %s;fi", RegistryName, RegistryName)
+	cmd := fmt.Sprintf("if docker inspect %s;then docker rm -f %[1]s;fi && (! nerdctl ps -a |grep %[1]s || nerdctl rmi -f %[1]s)", RegistryName)
 	return ssh.CmdAsync(k.RegConfig.IP, cmd)
 }
 


### PR DESCRIPTION
Optimize the automated build action, support containerd CRI,:

- There are two CRI types supported in the k8s [v1.20-v1.24.0) version: [ docker | containerd ]:
[Build command](https://github.com/sealerio/sealer/issues/1242): /imagebuild ${version} ${cri}
Example: /imagebuild v1.22.4 docker or /imagebuild v1.22.4 containerd.
Return the image name after the build is successful:
  - **CRI use docker**: kubernetes:${version} (cni: calico), kubernetes:${version}-alpine (without cni);
  - **CRI: containerd**: kubernetes-containerd:${version} (cni: calico), kubernetes:${version}-alpine (without cni).
ex.: 
![image](https://user-images.githubusercontent.com/69408038/168975238-387e5ccc-5995-4681-bc69-a060aea8c9a4.png)

- Docker is used for images below k8s v1.20, and containerd is used for images of v1.24 and above.
[Build command](https://github.com/sealerio/sealer/issues/1242): /imagebuild ${version}
Example: /imagebuild v1.19.5 or /imagebuild v1.24.0.
Return the image name after the build is successful:
  - **Include calico**: kubernetes:${version}
  - **Without calico**: kubernetes:${version}-alpine
 


ex.:
![image](https://user-images.githubusercontent.com/69408038/168975503-e79b7709-cee2-4b97-b038-3762ed94c9a5.png)
