### PR TITLE
bugfix: add deduplication operation for plugin load

### DIFF
--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -91,9 +91,7 @@ func (c *PluginsProcessor) Load() error {
 			var plugs []v1.Plugin
 			for _, p := range plugins.([]v1.Plugin) {
 				for _, cp := range c.Plugins {
-					if isSamePluginSpec(p, cp) {
-						continue
-					} else {
+					if !isSamePluginSpec(p, cp) {
 						plugs = append(plugs, p)
 					}
 				}

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -88,9 +88,20 @@ func (c *PluginsProcessor) Load() error {
 			if err != nil {
 				return fmt.Errorf("failed to load plugin %v", err)
 			}
-			c.Plugins = append(c.Plugins, plugins.([]v1.Plugin)...)
+			var plugs []v1.Plugin
+			for _, p := range plugins.([]v1.Plugin) {
+				for _, cp := range c.Plugins {
+					if isSamePluginSpec(p, cp) {
+						continue
+					} else {
+						plugs = append(plugs, p)
+					}
+				}
+			}
+			c.Plugins = append(c.Plugins, plugs...)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	v1 "github.com/sealerio/sealer/types/api/v1"
+
 	"github.com/sealerio/sealer/utils/net"
 
 	"github.com/sealerio/sealer/common"
@@ -62,4 +64,9 @@ func GetIpsByOnField(on string, context Context, phase Phase) (ipList []string, 
 		logger.Debug("node not found by on field [%s]", on)
 	}
 	return ipList, nil
+}
+
+func isSamePluginSpec(p1, p2 v1.Plugin) bool {
+	return p1.Spec.Type == p2.Spec.Type && p1.Spec.On == p2.Spec.On &&
+		p1.Spec.Data == p2.Spec.Data && p1.Spec.Action == p2.Spec.Action
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Background:

plugins which set in clusterfile and also existed in the cloud image, will be executed twice. so we need to remove the  duplicated plugins at load stage.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
fixes https://github.com/sealerio/sealer/issues/1460

### Describe how you did it

### Describe how to verify it

### Special notes for reviews
