### PR TITLE
fix: update size unit with GiB, MiB and KiB

### DIFF
--- a/cmd/sealer/cmd/images.go
+++ b/cmd/sealer/cmd/images.go
@@ -118,11 +118,11 @@ func formatSize(size int64) (Size string) {
 	if size < 1024 {
 		Size = fmt.Sprintf("%.2fB", float64(size)/float64(1))
 	} else if size < (1024 * 1024) {
-		Size = fmt.Sprintf("%.2fKB", float64(size)/float64(1024))
+		Size = fmt.Sprintf("%.2fKiB", float64(size)/float64(1024))
 	} else if size < (1024 * 1024 * 1024) {
-		Size = fmt.Sprintf("%.2fMB", float64(size)/float64(1024*1024))
+		Size = fmt.Sprintf("%.2fMiB", float64(size)/float64(1024*1024))
 	} else {
-		Size = fmt.Sprintf("%.2fGB", float64(size)/float64(1024*1024*1024))
+		Size = fmt.Sprintf("%.2fGiB", float64(size)/float64(1024*1024*1024))
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

update size unit with GiB, MiB and KiB.

Following the accurate size definition:

![截屏2022-06-06 19 57 13](https://user-images.githubusercontent.com/9465626/172156159-0332ae42-cc95-4cb3-b3e9-041d5c9b4069.png)



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
none

### Describe how you did it
none


### Describe how to verify it
none


### Special notes for reviews
none
