### PR TITLE
chore: replace cloud image with ClusterImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,35 +28,35 @@ sealer[ˈsiːlər] provides the way for distributed application package and deli
 
 > Concept
 
-* CloudImage : like Dockerimage, but the rootfs is kubernetes, and contains all the dependencies(docker images,yaml files or helm chart...) your application needs.
-* Kubefile : the file describe how to build a CloudImage.
-* Clusterfile : the config of using CloudImage to run a cluster.
+* ClusterImage : like Dockerimage, but the rootfs is kubernetes, and contains all the dependencies(docker images,yaml files or helm chart...) your application needs.
+* Kubefile : the file describe how to build a ClusterImage.
+* Clusterfile : the config of using ClusterImage to run a cluster.
 
 ![image](https://user-images.githubusercontent.com/8912557/117400612-97cf3a00-af35-11eb-90b9-f5dc8e8117b5.png)
 
-We can write a Kubefile, and build a CloudImage, then using a Clusterfile to run a cluster.
+We can write a Kubefile, and build a ClusterImage, then using a Clusterfile to run a cluster.
 
 sealer[ˈsiːlər] provides the way for distributed application package and delivery based on kubernetes.
 
 It solves the delivery problem of complex applications by packaging distributed applications and dependencies(like database,middleware) together.
 
-For example, build a dashboard CloudImage:
+For example, build a dashboard ClusterImage:
 
 Kubefile:
 
 ```shell script
-# base CloudImage contains all the files that run a kubernetes cluster needed.
+# base ClusterImage contains all the files that run a kubernetes cluster needed.
 #    1. kubernetes components like kubectl kubeadm kubelet and apiserver images ...
 #    2. docker engine, and a private registry
 #    3. config files, yaml, static files, scripts ...
 FROM registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8
 # download kubernetes dashboard yaml file
 RUN wget https://raw.githubusercontent.com/kubernetes/dashboard/v2.2.0/aio/deploy/recommended.yaml
-# when run this CloudImage, will apply a dashboard manifests
+# when run this ClusterImage, will apply a dashboard manifests
 CMD kubectl apply -f recommended.yaml
 ```
 
-Build dashobard CloudImage:
+Build dashobard ClusterImage:
 
 ```shell script
 sealer build -t registry.cn-qingdao.aliyuncs.com/sealer-io/dashboard:latest .
@@ -71,17 +71,17 @@ sealer run registry.cn-qingdao.aliyuncs.com/sealer-io/dashboard:latest --masters
 kubectl get pod -A|grep dashboard
 ```
 
-Push the CloudImage to the registry
+Push the ClusterImage to the registry
 
 ```shell script
-# you can push the CloudImage to docker hub, Ali ACR, or Harbor
+# you can push the ClusterImage to docker hub, Ali ACR, or Harbor
 sealer push registry.cn-qingdao.aliyuncs.com/sealer-io/dashboard:latest
 ```
 
 ## Usage scenarios & features
 
 * [x] An extremely simple way to install kubernetes and other software in the kubernetes ecosystem in a production or offline environment.
-* [x] Through Kubefile, you can easily customize the kubernetes CloudImage to package the cluster and applications, and submit them to the registry.
+* [x] Through Kubefile, you can easily customize the kubernetes ClusterImage to package the cluster and applications, and submit them to the registry.
 * [x] Powerful life cycle management capabilities, to perform operations such as cluster upgrade, cluster backup and recovery, node expansion and contraction in unimaginable simple ways
 * [x] Very fast, complete cluster installation within 3 minutes
 * [x] Support ARM x86, v1.20 and above versions support containerd, almost compatible with all Linux operating systems that support systemd

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## v0.1.3
 
 * general e2e tests
-* support build, apply and push a CloudImage
+* support build, apply and push a ClusterImage
 
 ## v0.2.0
 
@@ -23,7 +23,7 @@
 * rootfs mount filesystem
 * sealer hub UI
 
-## official registry opensource cloud images
+## official registry opensource ClusterImages
 
 * [ ] [dashboard](https://github.com/kubernetes/dashboard)
 * [ ] [prometheus stack](https://github.com/prometheus-operator/kube-prometheus)

--- a/apply/apply.go
+++ b/apply/apply.go
@@ -61,7 +61,7 @@ func NewApplierFromFile(path string) (applydriver.Interface, error) {
 		return nil, err
 	}
 
-	mounter, err := filesystem.NewCloudImageMounter()
+	mounter, err := filesystem.NewClusterImageMounter()
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +78,11 @@ func NewApplierFromFile(path string) (applydriver.Interface, error) {
 		cluster.SetAnnotations(common.ClusterfileName, path)
 	}
 	return &applydriver.Applier{
-		ClusterDesired:    &cluster,
-		ClusterFile:       Clusterfile,
-		ImageManager:      imgSvc,
-		CloudImageMounter: mounter,
-		ImageStore:        is,
+		ClusterDesired:      &cluster,
+		ClusterFile:         Clusterfile,
+		ImageManager:        imgSvc,
+		ClusterImageMounter: mounter,
+		ImageStore:          is,
 	}, nil
 }
 
@@ -99,7 +99,7 @@ func NewDefaultApplier(cluster *v2.Cluster) (applydriver.Interface, error) {
 		return nil, err
 	}
 
-	mounter, err := filesystem.NewCloudImageMounter()
+	mounter, err := filesystem.NewClusterImageMounter()
 	if err != nil {
 		return nil, err
 	}
@@ -110,9 +110,9 @@ func NewDefaultApplier(cluster *v2.Cluster) (applydriver.Interface, error) {
 	}
 
 	return &applydriver.Applier{
-		ClusterDesired:    cluster,
-		ImageManager:      imgSvc,
-		CloudImageMounter: mounter,
-		ImageStore:        is,
+		ClusterDesired:      cluster,
+		ImageManager:        imgSvc,
+		ClusterImageMounter: mounter,
+		ImageStore:          is,
 	}, nil
 }

--- a/apply/applydriver/local.go
+++ b/apply/applydriver/local.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/client/k8s"
 	"github.com/sealerio/sealer/pkg/clusterfile"
-	"github.com/sealerio/sealer/pkg/filesystem/cloudimage"
+	"github.com/sealerio/sealer/pkg/filesystem/clusterimage"
 	"github.com/sealerio/sealer/pkg/image"
 	"github.com/sealerio/sealer/pkg/image/store"
 	"github.com/sealerio/sealer/pkg/runtime"
@@ -39,16 +39,16 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-// Applier cloud builder using cloud provider to build a cluster image
+// Applier cloud builder using cloud provider to build a ClusterImage
 type Applier struct {
-	ClusterDesired     *v2.Cluster
-	ClusterCurrent     *v2.Cluster
-	ClusterFile        clusterfile.Interface
-	ImageManager       image.Service
-	CloudImageMounter  cloudimage.Interface
-	Client             *k8s.Client
-	ImageStore         store.ImageStore
-	CurrentClusterInfo *version.Info
+	ClusterDesired      *v2.Cluster
+	ClusterCurrent      *v2.Cluster
+	ClusterFile         clusterfile.Interface
+	ImageManager        image.Service
+	ClusterImageMounter clusterimage.Interface
+	Client              *k8s.Client
+	ImageStore          store.ImageStore
+	CurrentClusterInfo  *version.Info
 }
 
 func (c *Applier) Delete() (err error) {
@@ -106,7 +106,7 @@ func (c *Applier) mountClusterImage() error {
 	if err != nil {
 		return err
 	}
-	err = c.CloudImageMounter.MountImage(c.ClusterDesired)
+	err = c.ClusterImageMounter.MountImage(c.ClusterDesired)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (c *Applier) mountClusterImage() error {
 }
 
 func (c *Applier) unMountClusterImage() error {
-	return c.CloudImageMounter.UnMountImage(c.ClusterDesired)
+	return c.ClusterImageMounter.UnMountImage(c.ClusterDesired)
 }
 
 func (c *Applier) reconcileCluster() error {
@@ -224,7 +224,7 @@ func (c *Applier) upgrade() error {
 	}
 	logrus.Infof("Start to upgrade this cluster from version(%s) to version(%s)", c.CurrentClusterInfo.GitVersion, upgradeImgMeta.Version)
 
-	upgradeProcessor, err := processor.NewUpgradeProcessor(platform.DefaultMountCloudImageDir(c.ClusterDesired.Name), runtimeInterface)
+	upgradeProcessor, err := processor.NewUpgradeProcessor(platform.DefaultMountClusterImageDir(c.ClusterDesired.Name), runtimeInterface)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (c *Applier) initK8sClient() error {
 }
 
 func (c *Applier) installApp() error {
-	rootfs := platform.DefaultMountCloudImageDir(c.ClusterDesired.Name)
+	rootfs := platform.DefaultMountClusterImageDir(c.ClusterDesired.Name)
 	// use k8sClient to fetch current cluster version.
 	info := c.CurrentClusterInfo
 

--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	"github.com/sealerio/sealer/pkg/config"
 	"github.com/sealerio/sealer/pkg/filesystem"
-	"github.com/sealerio/sealer/pkg/filesystem/cloudimage"
+	"github.com/sealerio/sealer/pkg/filesystem/clusterimage"
 	"github.com/sealerio/sealer/pkg/guest"
 	"github.com/sealerio/sealer/pkg/image"
 	"github.com/sealerio/sealer/pkg/plugin"
@@ -36,7 +36,7 @@ import (
 type CreateProcessor struct {
 	ClusterFile       clusterfile.Interface
 	ImageManager      image.Service
-	cloudImageMounter cloudimage.Interface
+	cloudImageMounter clusterimage.Interface
 	Runtime           runtime.Interface
 	Guest             guest.Interface
 	Config            config.Interface
@@ -105,12 +105,12 @@ func (c *CreateProcessor) RunConfig(cluster *v2.Cluster) error {
 
 func (c *CreateProcessor) MountRootfs(cluster *v2.Cluster) error {
 	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
-	regConfig := runtime.GetRegistryConfig(platform.DefaultMountCloudImageDir(cluster.Name), cluster.GetMaster0IP())
+	regConfig := runtime.GetRegistryConfig(platform.DefaultMountClusterImageDir(cluster.Name), cluster.GetMaster0IP())
 	if net.NotInIPList(regConfig.IP, hosts) {
 		hosts = append(hosts, regConfig.IP)
 	}
 
-	fs, err := filesystem.NewFilesystem(platform.DefaultMountCloudImageDir(cluster.Name))
+	fs, err := filesystem.NewFilesystem(platform.DefaultMountClusterImageDir(cluster.Name))
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func NewCreateProcessor(clusterFile clusterfile.Interface) (Processor, error) {
 		return nil, err
 	}
 
-	mounter, err := filesystem.NewCloudImageMounter()
+	mounter, err := filesystem.NewClusterImageMounter()
 	if err != nil {
 		return nil, err
 	}

--- a/apply/processor/delete.go
+++ b/apply/processor/delete.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	"github.com/sealerio/sealer/pkg/filesystem"
 	"github.com/sealerio/sealer/pkg/filesystem/cloudfilesystem"
-	"github.com/sealerio/sealer/pkg/filesystem/cloudimage"
+	"github.com/sealerio/sealer/pkg/filesystem/clusterimage"
 	"github.com/sealerio/sealer/pkg/plugin"
 	"github.com/sealerio/sealer/pkg/runtime"
 	v2 "github.com/sealerio/sealer/types/api/v2"
@@ -29,7 +29,7 @@ import (
 )
 
 type DeleteProcessor struct {
-	cloudImageMounter cloudimage.Interface
+	cloudImageMounter clusterimage.Interface
 	ClusterFile       clusterfile.Interface
 	Plugins           plugin.Plugins
 }
@@ -91,7 +91,7 @@ func (d *DeleteProcessor) CleanFS(cluster *v2.Cluster) error {
 }
 
 func NewDeleteProcessor(clusterFile clusterfile.Interface) (Processor, error) {
-	mounter, err := filesystem.NewCloudImageMounter()
+	mounter, err := filesystem.NewClusterImageMounter()
 	if err != nil {
 		return nil, err
 	}

--- a/apply/processor/gen.go
+++ b/apply/processor/gen.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/client/k8s"
 	"github.com/sealerio/sealer/pkg/filesystem"
-	"github.com/sealerio/sealer/pkg/filesystem/cloudimage"
+	"github.com/sealerio/sealer/pkg/filesystem/clusterimage"
 	"github.com/sealerio/sealer/pkg/image"
 	"github.com/sealerio/sealer/pkg/runtime"
 	apiv1 "github.com/sealerio/sealer/types/api/v1"
@@ -54,11 +54,11 @@ type ParserArg struct {
 type GenerateProcessor struct {
 	Runtime      *runtime.KubeadmRuntime
 	ImageManager image.Service
-	ImageMounter cloudimage.Interface
+	ImageMounter clusterimage.Interface
 }
 
 func NewGenerateProcessor() (Processor, error) {
-	imageMounter, err := filesystem.NewCloudImageMounter()
+	imageMounter, err := filesystem.NewClusterImageMounter()
 	if err != nil {
 		return nil, err
 	}

--- a/apply/processor/install.go
+++ b/apply/processor/install.go
@@ -57,7 +57,7 @@ func (i *InstallProcessor) RunConfig(cluster *v2.Cluster) error {
 func (i *InstallProcessor) MountRootfs(cluster *v2.Cluster) error {
 	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
 	//initFlag : no need to do init cmd like installing docker service and so on.
-	fs, err := filesystem.NewFilesystem(platform.DefaultMountCloudImageDir(cluster.Name))
+	fs, err := filesystem.NewFilesystem(platform.DefaultMountClusterImageDir(cluster.Name))
 	if err != nil {
 		return err
 	}

--- a/cmd/sealer/cmd/build.go
+++ b/cmd/sealer/cmd/build.go
@@ -40,10 +40,10 @@ var buildConfig *BuildFlag
 // buildCmd represents the build command
 var buildCmd = &cobra.Command{
 	Use:   "build [flags] PATH",
-	Short: "build a CloudImage from a Kubefile",
-	Long: `build command is used to build a CloudImage from specified Kubefile.
+	Short: "build a ClusterImage from a Kubefile",
+	Long: `build command is used to build a ClusterImage from specified Kubefile.
 It organizes the specified Kubefile and input building context, and builds
-a brand new CloudImage.`,
+a brand new ClusterImage.`,
 	Args: cobra.ExactArgs(1),
 	Example: `the current path is the context path, default build type is lite and use build cache
 
@@ -92,13 +92,13 @@ build with args:
 func init() {
 	buildConfig = &BuildFlag{}
 	rootCmd.AddCommand(buildCmd)
-	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "CloudImage build type, default is lite")
+	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "ClusterImage build type, default is lite")
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "Kubefile filepath")
-	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "the name of CloudImage")
+	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "the name of ClusterImage")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
 	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image, default value is true.")
 	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build args")
-	buildCmd.Flags().StringVar(&buildConfig.Platform, "platform", "", "set CloudImage platform. If not set, keep same platform with runtime")
+	buildCmd.Flags().StringVar(&buildConfig.Platform, "platform", "", "set ClusterImage platform. If not set, keep same platform with runtime")
 
 	if err := buildCmd.MarkFlagRequired("imageName"); err != nil {
 		logrus.Errorf("failed to init flag: %v", err)

--- a/cmd/sealer/cmd/gen.go
+++ b/cmd/sealer/cmd/gen.go
@@ -35,7 +35,7 @@ var genCmd = &cobra.Command{
 
 The takeover actually is to generate a Clusterfile by kubeconfig.
 Sealer will call kubernetes API to get masters and nodes IP info, then generate a Clusterfile.
-Also sealer will pull a CloudImage which matches the kubernetes version.
+Also sealer will pull a ClusterImage which matches the kubernetes version.
 
 Check generated Clusterfile: 'cat .sealer/<cluster name>/Clusterfile'
 
@@ -49,7 +49,7 @@ Then you can use any sealer command to manage the cluster like:
 > Scale
 	sealer join --node x.x.x.x
 
-> Deploy a CloudImage into the cluster
+> Deploy a ClusterImage into the cluster
 	sealer run mysql-cluster:5.8`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flag.Passwd == "" || flag.Image == "" {
@@ -73,7 +73,7 @@ func init() {
 	genCmd.Flags().Uint16Var(&flag.Port, "port", 22, "set the sshd service port number for the server (default port: 22)")
 	genCmd.Flags().StringVar(&flag.Pk, "pk", cert.GetUserHomeDir()+"/.ssh/id_rsa", "set server private key")
 	genCmd.Flags().StringVar(&flag.PkPassword, "pk-passwd", "", "set server private key password")
-	genCmd.Flags().StringVar(&flag.Image, "image", "", "Set taken over CloudImage")
+	genCmd.Flags().StringVar(&flag.Image, "image", "", "Set taken over ClusterImage")
 	genCmd.Flags().StringVar(&flag.Name, "name", "default", "Set taken over cluster name")
 	genCmd.Flags().StringVar(&flag.Passwd, "passwd", "", "Set taken over ssh passwd")
 }

--- a/cmd/sealer/cmd/images.go
+++ b/cmd/sealer/cmd/images.go
@@ -39,7 +39,7 @@ const (
 
 var listCmd = &cobra.Command{
 	Use:   "images",
-	Short: "list all CloudImages on the local node",
+	Short: "list all ClusterImages on the local node",
 	// TODO: add long description.
 	Long:    "",
 	Args:    cobra.NoArgs,

--- a/cmd/sealer/cmd/inspect.go
+++ b/cmd/sealer/cmd/inspect.go
@@ -52,5 +52,5 @@ var inspectCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(inspectCmd)
-	inspectCmd.Flags().StringVar(&inspectPlatformFlag, "platform", "", "set CloudImage platform")
+	inspectCmd.Flags().StringVar(&inspectPlatformFlag, "platform", "", "set ClusterImage platform")
 }

--- a/cmd/sealer/cmd/load.go
+++ b/cmd/sealer/cmd/load.go
@@ -29,8 +29,8 @@ var imageSrc string
 // loadCmd represents the load command
 var loadCmd = &cobra.Command{
 	Use:     "load",
-	Short:   "load a CloudImage from a tar file",
-	Long:    `Load a CloudImage from a tar archive`,
+	Short:   "load a ClusterImage from a tar file",
+	Long:    `Load a ClusterImage from a tar archive`,
 	Example: `sealer load -i kubernetes.tar`,
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sealer/cmd/merge.go
+++ b/cmd/sealer/cmd/merge.go
@@ -46,7 +46,7 @@ merge images:
 	}
 	mf = &mergeFlag{}
 	mergeCmd.Flags().StringVarP(&mf.ImageName, "target-image", "t", "", "target image name")
-	mergeCmd.Flags().StringVar(&mf.Platform, "platform", "", "set CloudImage platform, if not set,keep same platform with runtime")
+	mergeCmd.Flags().StringVar(&mf.Platform, "platform", "", "set ClusterImage platform, if not set,keep same platform with runtime")
 
 	if err := mergeCmd.MarkFlagRequired("target-image"); err != nil {
 		logrus.Errorf("failed to init flag target image: %v", err)

--- a/cmd/sealer/cmd/pull.go
+++ b/cmd/sealer/cmd/pull.go
@@ -27,7 +27,7 @@ var platformFlag string
 // pullCmd represents the pull command
 var pullCmd = &cobra.Command{
 	Use:   "pull",
-	Short: "pull CloudImage from a registry to local",
+	Short: "pull ClusterImage from a registry to local",
 	// TODO: add long description.
 	Long:    "",
 	Example: `sealer pull registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8`,
@@ -52,5 +52,5 @@ var pullCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(pullCmd)
-	pullCmd.Flags().StringVar(&platformFlag, "platform", "", "set CloudImage platform")
+	pullCmd.Flags().StringVar(&platformFlag, "platform", "", "set ClusterImage platform")
 }

--- a/cmd/sealer/cmd/push.go
+++ b/cmd/sealer/cmd/push.go
@@ -24,7 +24,7 @@ import (
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
 	Use:   "push",
-	Short: "push CloudImage to remote registry",
+	Short: "push ClusterImage to remote registry",
 	// TODO: add long description.
 	Long:    "",
 	Example: `sealer push registry.cn-qingdao.aliyuncs.com/sealer-io/my-kubernetes-cluster-with-dashboard:latest`,

--- a/cmd/sealer/cmd/rmi.go
+++ b/cmd/sealer/cmd/rmi.go
@@ -78,5 +78,5 @@ func runRemove(images []string) error {
 func init() {
 	opts = removeImageFlag{}
 	rootCmd.AddCommand(rmiCmd)
-	rmiCmd.Flags().StringVar(&opts.platform, "platform", "", "set CloudImage platform")
+	rmiCmd.Flags().StringVar(&opts.platform, "platform", "", "set ClusterImage platform")
 }

--- a/cmd/sealer/cmd/root.go
+++ b/cmd/sealer/cmd/root.go
@@ -41,7 +41,7 @@ var rootCmd = &cobra.Command{
 	Use:   "sealer",
 	Short: "A tool to build, share and run any distributed applications.",
 	Long: `sealer is a tool to seal application's all dependencies and Kubernetes
-into CloudImage by Kubefile, distribute this application anywhere via CloudImage, 
+into ClusterImage by Kubefile, distribute this application anywhere via ClusterImage, 
 and run it within any cluster with Clusterfile in one command.
 `,
 }

--- a/cmd/sealer/cmd/run.go
+++ b/cmd/sealer/cmd/run.go
@@ -30,7 +30,7 @@ var runArgs *apply.Args
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "start to run a cluster from a CloudImage",
+	Short: "start to run a cluster from a ClusterImage",
 	Long:  `sealer run registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.19.8 --masters [arg] --nodes [arg]`,
 	Example: `
 create cluster to your bare metal server, appoint the iplist:

--- a/cmd/sealer/cmd/save.go
+++ b/cmd/sealer/cmd/save.go
@@ -38,7 +38,7 @@ var save saveFlag
 // saveCmd represents the save command
 var saveCmd = &cobra.Command{
 	Use:   "save",
-	Short: "save CloudImage to a tar file",
+	Short: "save ClusterImage to a tar file",
 	Long:  `sealer save -o [output file name] [image name]`,
 	Example: `
 save kubernetes:v1.19.8 image to kubernetes.tar file:
@@ -94,7 +94,7 @@ func init() {
 	rootCmd.AddCommand(saveCmd)
 	save = saveFlag{}
 	saveCmd.Flags().StringVarP(&save.ImageTar, "output", "o", "", "write the image to a file")
-	saveCmd.Flags().StringVar(&save.Platform, "platform", "", "set CloudImage platform")
+	saveCmd.Flags().StringVar(&save.Platform, "platform", "", "set ClusterImage platform")
 
 	if err := saveCmd.MarkFlagRequired("output"); err != nil {
 		logrus.Errorf("failed to init flag: %v", err)

--- a/cmd/sealer/cmd/search.go
+++ b/cmd/sealer/cmd/search.go
@@ -30,7 +30,7 @@ import (
 // searchCmd represents the search command
 var searchCmd = &cobra.Command{
 	Use:   "search",
-	Short: "search CloudImage in default registry",
+	Short: "search ClusterImage in default registry",
 	// TODO: add long description.
 	Long: "",
 	Example: `sealer search <imageDomain>/<imageRepo>/<imageName> ...

--- a/cmd/sealer/cmd/tag.go
+++ b/cmd/sealer/cmd/tag.go
@@ -22,7 +22,7 @@ import (
 
 var tagCmd = &cobra.Command{
 	Use:   "tag",
-	Short: "create a new tag that refers to a local CloudImage",
+	Short: "create a new tag that refers to a local ClusterImage",
 	// TODO: add long description.
 	Long:    "",
 	Example: `sealer tag kubernetes:v1.19.8 registry.cn-qingdao.aliyuncs.com/sealer-apps/kubernetes:v1.19.8`,

--- a/docs/api/clusterfile.md
+++ b/docs/api/clusterfile.md
@@ -9,7 +9,7 @@ metadata:
     sealer.aliyun.com/etcd: "/data/etcd"
     sealer.aliyun.com/docker: "/var/lib/docker"
 spec:
-  image: my-kubernetes:v1.18.3 # name of CloudImage
+  image: my-kubernetes:v1.18.3 # name of ClusterImage
   env: # the cluster global ENV
   - DOMAIN="sealer.alibaba.com"
   provider: ALI_CLOUD # OR BAREMETAL , CONTAINER.

--- a/docs/api/kubefile.md
+++ b/docs/api/kubefile.md
@@ -2,9 +2,9 @@
 
 ```shell script
 FROM kubernetes:1.18.0 # Base Image
-COPY wordpress-chart . # copy files to CloudImage
+COPY wordpress-chart . # copy files to ClusterImage
 COPY helm /bin
-RUN wget https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz # run command on building a CloudImage
+RUN wget https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz # run command on building a ClusterImage
 CMD helm install wordpress wordpress-chart  # run command on creating a cluster
 CMD helm list # multi CMD is valid
 ```

--- a/docs/commandline/sealer.md
+++ b/docs/commandline/sealer.md
@@ -14,19 +14,19 @@
 ### SEE ALSO
 
 * [sealer apply](sealer_apply.md)	 - apply a kubernetes cluster
-* [sealer build](sealer_build.md)	 - cloud image local build command line
+* [sealer build](sealer_build.md)	 - ClusterImage local build command line
 * [sealer check](sealer_check.md)	 - check the state of cluster 
 * [sealer completion](sealer_completion.md)	 - generate autocompletion script for bash
 * [sealer debug](sealer_debug.md)	 - Creating debugging sessions for pods and nodes
 * [sealer delete](sealer_delete.md)	 - delete a cluster
 * [sealer gen-doc](sealer_gen-doc.md)	 - Generate document for sealer CLI with MarkDown format
-* [sealer images](sealer_images.md)	 - list all cluster images
+* [sealer images](sealer_images.md)	 - list all ClusterImages
 * [sealer inspect](sealer_inspect.md)	 - print the image information or clusterFile
 * [sealer join](sealer_join.md)	 - join node to cluster
 * [sealer load](sealer_load.md)	 - load image
 * [sealer login](sealer_login.md)	 - login image repositories
-* [sealer pull](sealer_pull.md)	 - pull cloud image to local
-* [sealer push](sealer_push.md)	 - push cloud image to registry
+* [sealer pull](sealer_pull.md)	 - pull ClusterImage to local
+* [sealer push](sealer_push.md)	 - push ClusterImage to registry
 * [sealer rmi](sealer_rmi.md)	 - Remove local images by name or ID
 * [sealer run](sealer_run.md)	 - run a cluster with images and arguments
 * [sealer save](sealer_save.md)	 - save image

--- a/docs/commandline/sealer_build.md
+++ b/docs/commandline/sealer_build.md
@@ -1,6 +1,6 @@
 ## sealer build
 
-cloud image local build command line
+ClusterImage local build command line
 
 ### Synopsis
 
@@ -32,9 +32,9 @@ build without cache:
 ### Options
 
 ```
-  -m, --mode string   cluster image build type,default is cloud
+  -m, --mode string   ClusterImage build type,default is cloud
   -h, --help               help for build
-  -t, --imageName string   cluster image name
+  -t, --imageName string   ClusterImage name
   -f, --kubefile string    kubefile filepath (default "Kubefile")
       --no-cache           build without cache
 ```

--- a/docs/commandline/sealer_images.md
+++ b/docs/commandline/sealer_images.md
@@ -1,6 +1,6 @@
 ## sealer images
 
-list all cluster images
+list all ClusterImages
 
 ```
 sealer images [flags]

--- a/docs/commandline/sealer_pull.md
+++ b/docs/commandline/sealer_pull.md
@@ -1,6 +1,6 @@
 ## sealer pull
 
-pull cloud image to local
+pull ClusterImage to local
 
 ```
 sealer pull [flags]

--- a/docs/commandline/sealer_push.md
+++ b/docs/commandline/sealer_push.md
@@ -1,6 +1,6 @@
 ## sealer push
 
-push cloud image to registry
+push ClusterImage to registry
 
 ```
 sealer push [flags]

--- a/docs/design/Kubefile.md
+++ b/docs/design/Kubefile.md
@@ -3,11 +3,11 @@
 ## Introduction
 
 Kubefile is a script, composed of various commands(instructions) and arguments
-listed successively to automatically perform an action on a base CloudImage in
-order to create(or form) a new CloudImage. It is used by the sealer tool on
-only Linux platform for building CloudImage. The reason of naming it as Kubefile,
+listed successively to automatically perform an action on a base ClusterImage in
+order to create(or form) a new ClusterImage. It is used by the sealer tool on
+only Linux platform for building ClusterImage. The reason of naming it as Kubefile,
 which contains the same prefix 'Kube' of Kubernetes, is that there is always
-a Kubernetes binary located in each CloudImage. And when CloudImage is ran from
+a Kubernetes binary located in each ClusterImage. And when ClusterImage is ran from
 Kubefile, the built-in Kubernetes cluster will be setup and manage all infrastructure,
 and provide orchestration ability to upper applications.
 
@@ -25,7 +25,7 @@ prepare three nodes which meet the reprequisites of etcd installation, download
 and configure essential dependencies of etcd, and start to install and construct
 an etcd cluster. If etcd cluster is to be installed by Helm on an existing Kubernets,
 it could be shorten steps above without concerning about reprequisites and manually
-startup trigger. If there is no existing Kubernetes, Kubefile and CloudImage are
+startup trigger. If there is no existing Kubernetes, Kubefile and ClusterImage are
 the best to choice to setup etcd cluster with one command just in minutes.
 
 ## Concept Origin
@@ -33,11 +33,11 @@ the best to choice to setup etcd cluster with one command just in minutes.
 Kubefile has quite similar concept with Dockerfile. And Kubefile is indeed inpired
 by Dockerfile. Actullay, Dockerfile encapsulates single-host application(s) into a single-host
 box(Docker image). While Kubefile encapsulates cluster-level distributed
-application(s) into a cluster-level box(CloudImage).
+application(s) into a cluster-level box(ClusterImage).
 
 Docker uses Dockerfile to build Docker image, and run Docker container with Docker image.
 
-sealer uses Kubefile to build CloudImage, and run Kubernetes cluster with CloudImage.
+sealer uses Kubefile to build ClusterImage, and run Kubernetes cluster with ClusterImage.
 
 Docker tackles almost all of delivery issues of single-host application(s). sealer expands
 the concept to cluster level, and mostly focus on the perspetives of distributed application(s).
@@ -49,15 +49,15 @@ Kubefile's concept in built on the basis of Dockerfile, Kubernetes.
 
 Kubefile is always located somewhere on a machine, or in a git repository. It can be placed with binaries, packages,
 YAML files and any others. And it can be placed alone as well. Since Kubefile is used to
-build a CloudImage and CloudImage represents distributed application(s), there must be
-something else which should be included except Kubefile. It is **building context**, the context of CloudImage builing procedure.
+build a ClusterImage and ClusterImage represents distributed application(s), there must be
+something else which should be included except Kubefile. It is **building context**, the context of ClusterImage builing procedure.
 
 Here is a Kubefile folder example:
 
 ![image](https://user-images.githubusercontent.com/9465626/168005080-a9b47180-6284-484c-93bc-717e4e5f490f.png)
 
 There is a Kubefile and a `README.md` and `mysql-manifest.yaml` located in the
-folder. When a CloudImage is being built, the folder context is called
+folder. When a ClusterImage is being built, the folder context is called
 **building context**. In details, Kubefile has the following content:
 
 ```
@@ -69,24 +69,24 @@ CMD kubectl apply -f mysql-manifest.yaml
 Like what we defined Kubefile at the top of this documentation, this Kubefile
 contains three commands. Every command follows Kubefile syntax. Here are
 brief illustration of these commands. `FROM kubernetes:v1.18.3` tells user that
-the building CloudImage is from a `kubernetes:v1.18.3` CloudImage, or based on
+the building ClusterImage is from a `kubernetes:v1.18.3` ClusterImage, or based on
 `kubernetes:v1.18.3`. `COPY mysql-manifest.yaml .` means the building procedure
 should `COPY` a YAML file from the building context into the newly building
-CloudImage. `CMD kubectl apply -f mysql-manifest.yaml` sets an executable
-command of the CloudImage, and when the CloudImage runs up, the command will
+ClusterImage. `CMD kubectl apply -f mysql-manifest.yaml` sets an executable
+command of the ClusterImage, and when the ClusterImage runs up, the command will
 be executed automatically. For more commands type illustration, please refer
 to Kubefile Syntax.
 
 ## How to use Kubefile
 
 It is quite easy for engineers to use Kubefile. Just one command of `sealer build -f KUBEFILE_PATH .`.
-sealer is the tool which applies Kubefile and builds a CloudImage from Kubefile.
+sealer is the tool which applies Kubefile and builds a ClusterImage from Kubefile.
 In details, when engineer executes `sealer build` command, sealer binary will
 start to run as a process, pass on demand building context into process context,
 create a layer of OCI-compatible image for each command, and finally merge all
-layers to be a complete CloudImage. The CloudImage could be stored locally and
+layers to be a complete ClusterImage. The ClusterImage could be stored locally and
 pushed to remote image registries as well. In a word, engineer can use Kubefile
-to build CloudImage. Only CloudImage can be run to organize a cluster directly.
+to build ClusterImage. Only ClusterImage can be run to organize a cluster directly.
 
 ## Kubefile Command Syntax
 

--- a/docs/design/auto-build.md
+++ b/docs/design/auto-build.md
@@ -1,6 +1,6 @@
 # Auto-build
 
-Automatic cluster image build is to meet the needs of some users, Users need to build a specified version of kubernetes for automatic building.
+Automatic ClusterImage build is to meet the needs of some users, Users need to build a specified version of kubernetes for automatic building.
 
 ## Quick start
 Standard directive:

--- a/docs/design/clusterfile-v2.md
+++ b/docs/design/clusterfile-v2.md
@@ -93,7 +93,7 @@ spec:
 
 ### How to define your own kubeadm config
 
-The better way is to add kubeadm config directly into Clusterfile, of course every CloudImage has it default config:
+The better way is to add kubeadm config directly into Clusterfile, of course every ClusterImage has it default config:
 You can only define part of those configs, sealer will merge then into default config.
 
 ```yaml

--- a/docs/design/mutil_arch_build.md
+++ b/docs/design/mutil_arch_build.md
@@ -1,6 +1,6 @@
 # Multi-arch build
 
-## Build cloud image
+## Build ClusterImage
 
 Kubefile:
 
@@ -31,7 +31,7 @@ sealer build cmd line:
 sealer build --platform linux/arm64,linux/amd64 -t kubernetes-multi-arch:v1.19.8
 ```
 
-### Cloud image manifests list
+### ClusterImage manifests list
 
 ```json
 {
@@ -61,9 +61,9 @@ sealer build --platform linux/arm64,linux/amd64 -t kubernetes-multi-arch:v1.19.8
 }
 ```
 
-### Cloud image manifests
+### ClusterImage manifests
 
-#### amd64 cloud image
+#### amd64 ClusterImage
 
 `cat 52c3b10849c852649e66c2f7ed531f05bd97586ab61fa2cc82b4e79d80484b82.yaml`
 
@@ -112,7 +112,7 @@ spec:
 status: { }
 ```
 
-#### arm64 v8 cloud image
+#### arm64 v8 ClusterImage
 
 `cat 9e596d0a54177f29093236f65a9c6098590c67ea8b0dde4e09a5a49124cec7d0.yaml`
 
@@ -162,7 +162,7 @@ spec:
 status: { }
 ```
 
-## Run cloud image
+## Run ClusterImage
 
 | IP      | Platform | OS    |
 | :---        |    :----:   |          ---: |
@@ -188,7 +188,7 @@ we have three mounter point:
 1. For master:only have amdMounter data
 2. For node :only have armMounter data
 
-## Save cloud image
+## Save ClusterImage
 
 if not specify the platform will save them all. save two image_metadata.yaml and all manifests file.
 
@@ -216,30 +216,30 @@ manifests file and one image_metadata.yaml :
 }
 ```
 
-## Load cloud image
+## Load ClusterImage
 
 `sealer load -i kubernetes.tar`
 
-## Inspect cloud image
+## Inspect ClusterImage
 
 `sealer inspect b934b329d0e6f7abc4c37425a99a4683852e1308225ada4c1941f5df0d9a19f0`
 
-## Delete cloud image
+## Delete ClusterImage
 
 if not specify the platform will delete them all. If you only want to delete amd64 images of `kubernetes-multi-arch:
 v1.19.8`.
 
 `sealer rmi kubernetes-multi-arch:v1.19.8 --platform linux/amd64`
 
-## Pull cloud image
+## Pull ClusterImage
 
 `sealer pull kubernetes-multi-arch:v1.19.8 --platform linux/amd64`
 
-## Push cloud image
+## Push ClusterImage
 
 `sealer push kubernetes-multi-arch:v1.19.8 --platform linux/amd64`
 
-## Merge cloud image
+## Merge ClusterImage
 
 if not specify platform will use default arch with runtime. if specify platform, will merge them all.
 

--- a/docs/design/plugin.md
+++ b/docs/design/plugin.md
@@ -141,7 +141,7 @@ spec:
 at present, we only support the golang so file as out of tree plugin. More description about golang plugin
 see [golang plugin website](https://pkg.go.dev/plugin).
 
-copy the so file and the plugin config to your cloud image at build stage use `Kubefile`,sealer will parse and execute
+copy the so file and the plugin config to your ClusterImage at build stage use `Kubefile`,sealer will parse and execute
 it.
 
 plugin config:
@@ -166,7 +166,7 @@ COPY label_nodes.so plugin
 COPY label_nodes.yaml plugin
 ```
 
-Build a cluster image that contains the golang plugin (or more plugins):
+Build a ClusterImage that contains the golang plugin (or more plugins):
 
 ```shell script
 sealer build -m lite -t kubernetes-post-install:v1.19.8 .
@@ -245,7 +245,7 @@ FROM kubernetes:v1.19.8
 COPY shell.yaml plugin
 ```
 
-Build a cluster image that contains an installation iscsi plugin (or more plugins):
+Build a ClusterImage that contains an installation iscsi plugin (or more plugins):
 
 ```shell script
 sealer build -m lite -t kubernetes-iscsi:v1.19.8 .

--- a/docs/design/registry-image_zh.md
+++ b/docs/design/registry-image_zh.md
@@ -16,7 +16,7 @@
 ### 构建过程
 
 1. Build的时候对集群镜像里面的Docker镜像不作任何处理，以保障集群镜像"很小"
-2. CloudImage完全兼容OCI
+2. ClusterImage完全兼容OCI
 
 ### Save过程
 
@@ -27,7 +27,7 @@
 ### Run 过程
 
 1. registry module根据registry的配置拉起registry.
-2. 根据CloudImage Name在所有节点拉取集群镜像
+2. 根据ClusterImage Name在所有节点拉取集群镜像
 3. 启动k8s和guest
 4. kubelet自动拉起其它镜像
 5. 可以利用运行时自身能力去判断多架构并拉取对应架构的镜像

--- a/pkg/cloud/README.md
+++ b/pkg/cloud/README.md
@@ -1,5 +1,5 @@
 # sealer cloud
 
-sealer cloud is a platform for use Build&Share&Run CloudImage online.
+sealer cloud is a platform for use Build&Share&Run ClusterImage online.
 
 Using rust and wasm to write a web UI for sealer.

--- a/pkg/filesystem/README.md
+++ b/pkg/filesystem/README.md
@@ -1,6 +1,6 @@
 # rootfs dir
 
-> CloudImage Mount Dir
+> ClusterImage Mount Dir
 
 ```shell script
 /var/lib/sealer/data/<my-cluster>/mount

--- a/pkg/filesystem/cloudfilesystem/nydus.go
+++ b/pkg/filesystem/cloudfilesystem/nydus.go
@@ -84,7 +84,7 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 		return fmt.Errorf("failed to get local address, %v", err)
 	}
 	var (
-		nydusdfileSrc   = filepath.Join(platform.DefaultMountCloudImageDir(cluster.Name), "nydusdfile")
+		nydusdfileSrc   = filepath.Join(platform.DefaultMountClusterImageDir(cluster.Name), "nydusdfile")
 		nydusdFileDir   = common.DefaultTheClusterNydusdFileDir(cluster.Name)
 		nydusdserverDir = filepath.Join(nydusdFileDir, "serverfile")
 		nydusdfileCpCmd = fmt.Sprintf("rm -rf %s && cp -r %s %s", nydusdFileDir, nydusdfileSrc, nydusdFileDir)
@@ -93,7 +93,7 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 		nydusdCleanCmd  = fmt.Sprintf(RemoteNydusdStop, filepath.Join(nydusdDir, "clean.sh"), nydusdDir)
 		cleanCmd        = fmt.Sprintf("echo '%s' >> "+common.DefaultClusterClearBashFile, nydusdCleanCmd, cluster.Name)
 		envProcessor    = env.NewEnvProcessor(cluster)
-		config          = runtime.GetRegistryConfig(platform.DefaultMountCloudImageDir(cluster.Name), cluster.GetMaster0IP())
+		config          = runtime.GetRegistryConfig(platform.DefaultMountClusterImageDir(cluster.Name), cluster.GetMaster0IP())
 		initCmd         = fmt.Sprintf(RemoteChmod, target, config.Domain, config.Port)
 	)
 	_, err = exec.RunSimpleCmd(nydusdfileCpCmd)
@@ -105,7 +105,7 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 	dirlist := ""
 	for _, IP := range ipList {
 		ip := IP
-		src := platform.GetMountCloudImagePlatformDir(cluster.Name, clusterPlatform[ip])
+		src := platform.GetMountClusterImagePlatformDir(cluster.Name, clusterPlatform[ip])
 		if !mountDirs[src] {
 			mountDirs[src] = true
 			dirlist = dirlist + fmt.Sprintf(",%s", src)
@@ -130,7 +130,7 @@ func mountNydusRootfs(ipList []string, target string, cluster *v2.Cluster, initF
 	for _, IP := range ipList {
 		ip := IP
 		eg.Go(func() error {
-			src := platform.GetMountCloudImagePlatformDir(cluster.Name, clusterPlatform[ip])
+			src := platform.GetMountClusterImagePlatformDir(cluster.Name, clusterPlatform[ip])
 			src = filepath.Join(nydusdFileDir, filepath.Base(src))
 			sshClient, err := ssh.GetHostSSHClient(ip, cluster)
 			if err != nil {

--- a/pkg/filesystem/cloudfilesystem/overlay2.go
+++ b/pkg/filesystem/cloudfilesystem/overlay2.go
@@ -63,12 +63,12 @@ func mountRootfs(ipList []string, target string, cluster *v2.Cluster, initFlag b
 		*sync.RWMutex
 		mountDirs map[string]bool
 	}{&sync.RWMutex{}, make(map[string]bool)}
-	config := runtime.GetRegistryConfig(platform.DefaultMountCloudImageDir(cluster.Name), cluster.GetMaster0IP())
+	config := runtime.GetRegistryConfig(platform.DefaultMountClusterImageDir(cluster.Name), cluster.GetMaster0IP())
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, IP := range ipList {
 		ip := IP
 		eg.Go(func() error {
-			src := platform.GetMountCloudImagePlatformDir(cluster.Name, clusterPlatform[ip])
+			src := platform.GetMountClusterImagePlatformDir(cluster.Name, clusterPlatform[ip])
 			initCmd := fmt.Sprintf(RemoteChmod, target, config.Domain, config.Port)
 			mountEntry.Lock()
 			if !mountEntry.mountDirs[src] {

--- a/pkg/filesystem/clusterimage/clusterimage.go
+++ b/pkg/filesystem/clusterimage/clusterimage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cloudimage
+package clusterimage
 
 import (
 	"fmt"
@@ -92,7 +92,7 @@ func (m *mounter) mountImage(cluster *v2.Cluster) error {
 	clusterPlatform["local"] = *platform.GetDefaultPlatform()
 	for _, v := range clusterPlatform {
 		pfm := v
-		mountDir := platform.GetMountCloudImagePlatformDir(cluster.Name, pfm)
+		mountDir := platform.GetMountClusterImagePlatformDir(cluster.Name, pfm)
 		upperDir := filepath.Join(mountDir, "upper")
 		if mountDirs[mountDir] {
 			continue
@@ -153,7 +153,7 @@ func renderENV(imageMountDir string, ipList []string, p env.Interface) error {
 	return nil
 }
 
-func NewCloudImageMounter(is store.ImageStore) (Interface, error) {
+func NewClusterImageMounter(is store.ImageStore) (Interface, error) {
 	return &mounter{
 		imageStore: is,
 		fs:         fs.NewFilesystem(),

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -18,18 +18,18 @@ import (
 	"fmt"
 
 	"github.com/sealerio/sealer/pkg/filesystem/cloudfilesystem"
-	"github.com/sealerio/sealer/pkg/filesystem/cloudimage"
+	"github.com/sealerio/sealer/pkg/filesystem/clusterimage"
 	"github.com/sealerio/sealer/pkg/image/store"
 	"github.com/sealerio/sealer/pkg/runtime"
 )
 
-// NewCloudImageMounter :mount and unmount cloud image.
-func NewCloudImageMounter() (cloudimage.Interface, error) {
+// NewCloudClusterMounter :mount and unmount ClusterImage.
+func NewClusterImageMounter() (clusterimage.Interface, error) {
 	is, err := store.NewDefaultImageStore()
 	if err != nil {
 		return nil, err
 	}
-	return cloudimage.NewCloudImageMounter(is)
+	return clusterimage.NewClusterImageMounter(is)
 }
 
 // NewFilesystem :according to the Metadata file content to determine what kind of Filesystem will be load.

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -56,7 +56,7 @@ func (d *Default) Apply(cluster *v2.Cluster) error {
 
 	image, err := d.imageStore.GetByName(cluster.Spec.Image, platform.GetDefaultPlatform())
 	if err != nil {
-		return fmt.Errorf("get cluster image failed, %s", err)
+		return fmt.Errorf("get ClusterImage failed, %s", err)
 	}
 	cmdArgs := d.getGuestCmdArg(cluster, image)
 	cmd := d.getGuestCmd(cluster, image)

--- a/pkg/image/default_image_metadata.go
+++ b/pkg/image/default_image_metadata.go
@@ -70,7 +70,7 @@ func (d DefaultImageMetadataService) Tag(imageName, tarImageName string) error {
 	return nil
 }
 
-//List will list all cloud image locally
+//List will list all ClusterImage locally
 func (d DefaultImageMetadataService) List() (store.ImageMetadataMap, error) {
 	return d.imageStore.GetImageMetadataMap()
 }

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -63,7 +63,7 @@ func NewPlugins(cluster *v2.Cluster, plugins []v1.Plugin) Plugins {
 
 // Load plugin configs and shared object(.so) file from $mountRootfs/plugins dir.
 func (c *PluginsProcessor) Load() error {
-	path := filepath.Join(platform.DefaultMountCloudImageDir(c.Cluster.Name), "plugins")
+	path := filepath.Join(platform.DefaultMountClusterImageDir(c.Cluster.Name), "plugins")
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return nil

--- a/pkg/runtime/kubeadm_config.go
+++ b/pkg/runtime/kubeadm_config.go
@@ -57,7 +57,7 @@ func (k *KubeadmConfig) LoadFromClusterfile(kubeadmConfig *KubeadmConfig) error 
 	return mergo.Merge(k, kubeadmConfig)
 }
 
-// Merge Using github.com/imdario/mergo to merge KubeadmConfig to the CloudImage default kubeadm config, overwrite some field.
+// Merge Using github.com/imdario/mergo to merge KubeadmConfig to the ClusterImage default kubeadm config, overwrite some field.
 // if defaultKubeadmConfig file not exist, use default raw kubeadm config to merge k.KubeConfigSpec empty value
 func (k *KubeadmConfig) Merge(kubeadmYamlPath string) error {
 	var (

--- a/pkg/runtime/kubeadm_runtime.go
+++ b/pkg/runtime/kubeadm_runtime.go
@@ -105,7 +105,7 @@ func (k *KubeadmRuntime) getRootfs() string {
 
 // /var/lib/sealer/data/my-cluster/mount
 func (k *KubeadmRuntime) getImageMountDir() string {
-	return platform.DefaultMountCloudImageDir(k.getClusterName())
+	return platform.DefaultMountClusterImageDir(k.getClusterName())
 }
 
 // /var/lib/sealer/data/my-cluster/certs

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -86,7 +86,7 @@ func GetKubectlAndKubeconfig(ssh ssh.Interface, host, rootfs string) error {
 	return nil
 }
 
-// LoadMetadata :read metadata via cluster image name.
+// LoadMetadata :read metadata via ClusterImage name.
 func LoadMetadata(rootfs string) (*Metadata, error) {
 	metadataPath := filepath.Join(rootfs, common.DefaultMetadataName)
 	var metadataFile []byte
@@ -98,16 +98,16 @@ func LoadMetadata(rootfs string) (*Metadata, error) {
 
 	metadataFile, err = ioutil.ReadFile(filepath.Clean(metadataPath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read CloudImage metadata %v", err)
+		return nil, fmt.Errorf("failed to read ClusterImage metadata %v", err)
 	}
 	err = json.Unmarshal(metadataFile, &md)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load CloudImage metadata %v", err)
+		return nil, fmt.Errorf("failed to load ClusterImage metadata %v", err)
 	}
 	return &md, nil
 }
 
-func GetCloudImagePlatform(rootfs string) (cp ocispecs.Platform) {
+func GetClusterImagePlatform(rootfs string) (cp ocispecs.Platform) {
 	// current we only support build on linux
 	cp = ocispecs.Platform{
 		Architecture: "amd64",

--- a/test/sealer_apply_test.go
+++ b/test/sealer_apply_test.go
@@ -33,7 +33,7 @@ var _ = Describe("sealer apply", func() {
 		rawCluster.Spec.Image = settings.TestImageName
 		BeforeEach(func() {
 			if rawCluster.Spec.Image != settings.TestImageName {
-				//rawCluster imageName updated to customImageName
+				//rawClusterImageName updated to customImageName
 				rawCluster.Spec.Image = settings.TestImageName
 				apply.MarshalClusterToFile(rawClusterFilePath, rawCluster)
 			}

--- a/utils/platform/platform.go
+++ b/utils/platform/platform.go
@@ -243,10 +243,10 @@ func normalizeOS(os string) string {
 	return os
 }
 
-func DefaultMountCloudImageDir(clusterName string) string {
-	return GetMountCloudImagePlatformDir(clusterName, *GetDefaultPlatform())
+func DefaultMountClusterImageDir(clusterName string) string {
+	return GetMountClusterImagePlatformDir(clusterName, *GetDefaultPlatform())
 }
 
-func GetMountCloudImagePlatformDir(clusterName string, platform v1.Platform) string {
+func GetMountClusterImagePlatformDir(clusterName string, platform v1.Platform) string {
 	return filepath.Join(common.DefaultClusterRootfsDir, clusterName, "mount", fmt.Sprintf("%s_%s_%s", platform.OS, platform.Architecture, platform.Variant))
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Like what mentioned in https://github.com/sealerio/sealer/issues/1371 .

Currently in sealer's concept, CloudImage represents the Image which is built from Kubefile. CloudImage now is used to reveal a cluster with applications and Kubernetes inside.

While I am just wondering if Cloud in CloudImage is the suitable name for this situation. Cloud generally refers to a quite wide and abstract service all around the industry. Maybe CloudImage is much larger than what sealer wishes to mean.

Back to the theme, I think maybe ClusterImage is a little bit more accurate than CloudImage.

Just propose this topic to all the community and maintainer to take this into consideration.

In addition, in gravity https://github.com/gravitational/gravity, it refers to ClusterImage as well: https://github.com/gravitational/gravity#cluster-images

### Does this pull request fix one issue?
fixes https://github.com/sealerio/sealer/issues/1371
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
none