### PR TITLE
[WIP] bugfix: use kubeadm config file to upgrade

### DIFF
--- a/pkg/runtime/default_kubeadm_config.go
+++ b/pkg/runtime/default_kubeadm_config.go
@@ -113,7 +113,7 @@ authorization:
   webhook:
     cacheAuthorizedTTL: 5m0s
     cacheUnauthorizedTTL: 30s
-cgroupDriver:
+cgroupDriver: systemd
 cgroupsPerQOS: true
 clusterDomain: cluster.local
 configMapAndSecretChangeDetectionStrategy: Watch

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -20,14 +20,14 @@ import (
 )
 
 const (
-	chmodCmd         = `chmod +x %s/*`
-	mvCmd            = `mv %s/* /usr/bin`
-	getNodeNameCmd   = `$(uname -n | tr '[A-Z]' '[a-z]')`
-	drainCmd         = `kubectl drain ` + getNodeNameCmd + ` --ignore-daemonsets`
-	upgradeMater0Cmd = `kubeadm upgrade apply %s --config=%s/etc/kubeadm.yml -y`
-	upgradeCmd       = `kubeadm upgrade node`
-	restartCmd       = `systemctl daemon-reload && systemctl restart kubelet`
-	uncordonCmd      = `kubectl uncordon ` + getNodeNameCmd
+	chmodCmd          = `chmod +x %s/*`
+	mvCmd             = `mv %s/* /usr/bin`
+	getNodeNameCmd    = `$(uname -n | tr '[A-Z]' '[a-z]')`
+	drainCmd          = `kubectl drain ` + getNodeNameCmd + ` --ignore-daemonsets`
+	upgradeMaster0Cmd = `kubeadm upgrade apply %s --config=%s/etc/kubeadm.yml -y`
+	upgradeCmd        = `kubeadm upgrade node`
+	restartCmd        = `systemctl daemon-reload && systemctl restart kubelet`
+	uncordonCmd       = `kubectl uncordon ` + getNodeNameCmd
 )
 
 func (k *KubeadmRuntime) upgrade() error {
@@ -61,7 +61,7 @@ func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binPath, version string) 
 		fmt.Sprintf(chmodCmd, binPath),
 		fmt.Sprintf(mvCmd, binPath),
 		drain,
-		fmt.Sprintf(upgradeMater0Cmd, version, k.getRootfs()),
+		fmt.Sprintf(upgradeMaster0Cmd, version, k.getRootfs()),
 		restartCmd,
 		uncordonCmd,
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

dns imageRepository was changed from "k8s.gcr.io/coredns" to "k8s.gcr.io/**coredns**/coredns" after the  kubernetes v1.20.

so need to set the related dns imageRepository at kubeadm.yml, and using this config file to do cluster init or cluster upgrade will fix this issue.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

fixes: #1428

### Describe how you did it


### Describe how to verify it


### Special notes for reviews

refer to https://github.com/sealerio/rootfs/blob/main/DESIGN.MD#special-case-for-note
