### PR TITLE
bugfix: add auth flag for cluster scale

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -86,10 +86,6 @@ func NewApplierFromFile(path string) (applydriver.Interface, error) {
 	}, nil
 }
 
-func NewApplier(cluster *v2.Cluster) (applydriver.Interface, error) {
-	return NewDefaultApplier(cluster)
-}
-
 func NewDefaultApplier(cluster *v2.Cluster) (applydriver.Interface, error) {
 	if cluster.Name == "" {
 		return nil, fmt.Errorf("cluster name cannot be empty")

--- a/apply/processor/gen.go
+++ b/apply/processor/gen.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/sealerio/sealer/utils/yaml"
+	"github.com/sealerio/sealer/pkg/clusterfile"
 
 	"github.com/sealerio/sealer/utils/net"
 
@@ -74,7 +74,7 @@ func NewGenerateProcessor() (Processor, error) {
 
 func (g *GenerateProcessor) init(cluster *v2.Cluster) error {
 	fileName := fmt.Sprintf("%s/.sealer/%s/Clusterfile", common.GetHomeDir(), cluster.Name)
-	if err := yaml.MarshalToFile(fileName, cluster); err != nil {
+	if err := clusterfile.SaveToDisk(cluster, fileName); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/sealer/cmd/delete.go
+++ b/cmd/sealer/cmd/delete.go
@@ -96,6 +96,7 @@ func init() {
 	deleteCmd.Flags().StringVarP(&deleteArgs.Nodes, "nodes", "n", "", "reduce Count or IPList to nodes")
 	deleteCmd.Flags().StringVarP(&deleteClusterFile, "Clusterfile", "f", "", "delete a kubernetes cluster with Clusterfile Annotations")
 	deleteCmd.Flags().StringVarP(&deleteClusterName, "cluster", "c", "", "delete a kubernetes cluster with cluster name")
+	deleteCmd.Flags().StringSliceVarP(&deleteArgs.CustomEnv, "env", "e", []string{}, "set custom environment variables")
 	deleteCmd.Flags().BoolVar(&runtime.ForceDelete, "force", false, "We also can input an --force flag to delete cluster by force")
 	deleteCmd.Flags().BoolP("all", "a", false, "this flags is for delete nodes, if this is true, empty all node ip")
 }

--- a/cmd/sealer/cmd/join.go
+++ b/cmd/sealer/cmd/join.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/sealerio/sealer/pkg/cert"
 	"github.com/spf13/cobra"
 
 	"github.com/sealerio/sealer/apply"
@@ -56,6 +57,14 @@ join default cluster:
 func init() {
 	joinArgs = &apply.Args{}
 	rootCmd.AddCommand(joinCmd)
+
+	joinCmd.Flags().StringVarP(&joinArgs.User, "user", "u", "root", "set baremetal server username")
+	joinCmd.Flags().StringVarP(&joinArgs.Password, "passwd", "p", "", "set cloud provider or baremetal server password")
+	joinCmd.Flags().Uint16Var(&joinArgs.Port, "port", 22, "set the sshd service port number for the server (default port: 22)")
+	joinCmd.Flags().StringVar(&joinArgs.Pk, "pk", cert.GetUserHomeDir()+"/.ssh/id_rsa", "set baremetal server private key")
+	joinCmd.Flags().StringVar(&joinArgs.PkPassword, "pk-passwd", "", "set baremetal server private key password")
+	joinCmd.Flags().StringSliceVarP(&joinArgs.CustomEnv, "env", "e", []string{}, "set custom environment variables")
+
 	joinCmd.Flags().StringVarP(&joinArgs.Masters, "masters", "m", "", "set Count or IPList to masters")
 	joinCmd.Flags().StringVarP(&joinArgs.Nodes, "nodes", "n", "", "set Count or IPList to nodes")
 	joinCmd.Flags().StringVarP(&clusterName, "cluster-name", "c", "", "specify the name of cluster")

--- a/cmd/sealer/cmd/upgrade.go
+++ b/cmd/sealer/cmd/upgrade.go
@@ -53,7 +53,7 @@ var upgradeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		applier, err := apply.NewApplier(desiredCluster)
+		applier, err := apply.NewDefaultApplier(desiredCluster)
 		if err != nil {
 			return err
 		}

--- a/pkg/clusterfile/util.go
+++ b/pkg/clusterfile/util.go
@@ -21,12 +21,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sealerio/sealer/utils/hash"
+
 	yamlUtils "github.com/sealerio/sealer/utils/yaml"
 
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/cert"
 	v2 "github.com/sealerio/sealer/types/api/v2"
-	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 var ErrClusterNotExist = fmt.Errorf("no cluster exist")
@@ -72,13 +73,42 @@ func GetDefaultCluster() (cluster *v2.Cluster, err error) {
 	return GetClusterFromFile(fmt.Sprintf("%s/.sealer/%s/Clusterfile", userHome, name))
 }
 
-func SaveToDisk(cluster k8sRuntime.Object, clusterName string) error {
+// SaveToDisk save cluster obj to disk file with encrypted ssh credential
+func SaveToDisk(cluster *v2.Cluster, clusterName string) error {
 	fileName := common.GetClusterWorkClusterfile(clusterName)
 	err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("mkdir failed %s %v", fileName, err)
 	}
-	cluster = cluster.DeepCopyObject()
+
+	// if user run cluster image without password,skip to encrypt.
+	if !cluster.Spec.SSH.Encrypted && cluster.Spec.SSH.Passwd != "" {
+		passwd, err := hash.AesEncrypt([]byte(cluster.Spec.SSH.Passwd))
+		if err != nil {
+			return err
+		}
+		cluster.Spec.SSH.Passwd = passwd
+		cluster.Spec.SSH.Encrypted = true
+	}
+
+	var hosts []v2.Host
+	for _, host := range cluster.Spec.Hosts {
+		if len(host.IPS) == 0 {
+			continue
+		}
+		if !host.SSH.Encrypted && host.SSH.Passwd != "" {
+			passwd, err := hash.AesEncrypt([]byte(host.SSH.Passwd))
+			if err != nil {
+				return err
+			}
+			host.SSH.Passwd = passwd
+			host.SSH.Encrypted = true
+		}
+		hosts = append(hosts, host)
+	}
+
+	cluster.Spec.Hosts = hosts
+
 	err = yamlUtils.MarshalToFile(fileName, cluster)
 	if err != nil {
 		return fmt.Errorf("marshal cluster file failed %v", err)

--- a/utils/yaml/yaml.go
+++ b/utils/yaml/yaml.go
@@ -24,12 +24,7 @@ import (
 
 	osi "github.com/sealerio/sealer/utils/os"
 
-	"github.com/sealerio/sealer/utils/hash"
-
 	"sigs.k8s.io/yaml"
-
-	v1 "github.com/sealerio/sealer/types/api/v1"
-	v2 "github.com/sealerio/sealer/types/api/v2"
 )
 
 func UnmarshalFile(file string, obj interface{}) error {
@@ -46,29 +41,6 @@ func UnmarshalFile(file string, obj interface{}) error {
 }
 
 func MarshalToFile(file string, obj interface{}) error {
-	switch cluster := obj.(type) {
-	case *v1.Cluster:
-		if cluster.Spec.SSH.Encrypted {
-			break
-		}
-		passwd, err := hash.AesEncrypt([]byte(cluster.Spec.SSH.Passwd))
-		if err != nil {
-			return err
-		}
-		cluster.Spec.SSH.Passwd = passwd
-		cluster.Spec.SSH.Encrypted = true
-	case *v2.Cluster:
-		if cluster.Spec.SSH.Encrypted {
-			break
-		}
-		passwd, err := hash.AesEncrypt([]byte(cluster.Spec.SSH.Passwd))
-		if err != nil {
-			return err
-		}
-		cluster.Spec.SSH.Passwd = passwd
-		cluster.Spec.SSH.Encrypted = true
-	default:
-	}
 	data, err := yaml.Marshal(obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. add ssh auth flag and env for sealer join.
2. add env flag for sealer delete.
3. split cluster v1 and cluster v2 save logic at Clusterfile saving stage.
4. avoid adding empty struct filed  of Clusterfile.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

fixes #1469 

### Describe how you did it


### Describe how to verify it

test success  on my side:

all cluster node use the same password:

```shell
sealer run kubernetes:v1.21.12 -m 172.16.0.200 -p password
sealer join kubernetes:v1.21.12 -n 172.16.0.201
sealer delete -n 172.16.0.201
```

```shell
sealer run kubernetes:v1.21.12 # local host as master0, no need to set password
sealer join kubernetes:v1.21.12 -n 172.16.0.201 -p password123 # if join another node, need to set password.
sealer delete -n 172.16.0.201
```

all cluster node use the different  password:

```shell
sealer run kubernetes:v1.21.12 -m 172.16.0.200 -p password
sealer join kubernetes:v1.21.12 -n 172.16.0.201 -p password123
sealer delete -n 172.16.0.201 
```









### Special notes for reviews
