### PR TITLE
Use template from go standard library rather than html's

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -16,12 +16,10 @@ package env
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/Masterminds/sprig/v3"
+	"text/template"
 
 	v2 "github.com/sealerio/sealer/types/api/v2"
 )
@@ -79,7 +77,7 @@ func (p *processor) RenderAll(host, dir string) error {
 		defer func() {
 			_ = writer.Close()
 		}()
-		t, err := template.New(info.Name()).Funcs(sprig.FuncMap()).ParseFiles(path)
+		t, err := template.New(info.Name()).ParseFiles(path)
 		if err != nil {
 			return fmt.Errorf("failed to create template: %s %v", path, err)
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

使用go标准库的template能力，而非来源于html库的。

在测试中发现，html库的template行为，与go标准库所描述的并不一致。例如，and函数的go标准库描述如下：
```
and
	Returns the boolean AND of its arguments by returning the
	first empty argument or the last argument. That is,
	"and x y" behaves as "if x then y else x."
	Evaluation proceeds through the arguments left to right
	and returns when the result is determined.
```

这也符合常识，当AND的左操作字为false时，将不会再去检查右操作字，这在很多场景下是有用的，例如：
{{ if and (.HostIPFamily) (eq .HostIPFamily "6") }}，这一行判断可以cover住HostIPFamily未定义的场景。

然而，当我使用html库的template来渲染时，它总是渲染失败。

因此，我希望替换sealer中的template库：https://pkg.go.dev/text/template，使用go标准库将符合大多数人的认知。

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
