### PR TITLE
shell: make sh and /bin/bash compatible on more OS(Ubuntu)

### DIFF
--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -70,7 +70,7 @@ func (k *KubeadmRuntime) ApplyRegistry() error {
 			return err
 		}
 	}
-	initRegistry := fmt.Sprintf("cd %s/scripts && sh init-registry.sh %s %s %s", k.getRootfs(), k.RegConfig.Port, fmt.Sprintf("%s/registry", k.getRootfs()), k.RegConfig.Domain)
+	initRegistry := fmt.Sprintf("cd %s/scripts && ./init-registry.sh %s %s %s", k.getRootfs(), k.RegConfig.Port, fmt.Sprintf("%s/registry", k.getRootfs()), k.RegConfig.Domain)
 	registryHost := k.getRegistryHost()
 	addRegistryHosts := fmt.Sprintf(RemoteAddEtcHosts, registryHost, registryHost)
 	if k.RegConfig.Domain != SeaHub {


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

`sh init-registry.sh` brings incompatibility on Ubuntu 20.04 LTS. We see that in init-registry.sh there is a shenbang `#!/bin/bash`.  And when using `sh` to execute file, there will be some places displaying:
```
+ check_registry
+ n=1
init-registry.sh: 44: cannot open =: No such file
+ n 3
init-registry.sh: 44: n: not found
```

We update that with `./init-registry`, and it would be the default shenbang `#!/bin/bash` to execute the shell file.

### Does this pull request fix one issue?
fixes https://github.com/sealerio/sealer/issues/1507

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none


### Describe how to verify it
none


### Special notes for reviews
