### PR TITLE
cmd: update cobra command option to silence usage and error

### DIFF
--- a/cmd/sealer/cmd/root.go
+++ b/cmd/sealer/cmd/root.go
@@ -44,6 +44,8 @@ var rootCmd = &cobra.Command{
 into ClusterImage by Kubefile, distribute this application anywhere via ClusterImage, 
 and run it within any cluster with Clusterfile in one command.
 `,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

### Describe what this PR does / why we need it

Every time when we support end user, I found that there are always command usage information and duplicated error. It makes information less explicit. We make the cobra not to print usage info and just print one time of error. 


### Does this pull request fix one issue?
none
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
none