### PR TITLE
fix: the issue template can't match the labels in Sealer which named …

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug encountered while operating sealer
-labels: ["bug"]
+labels: ["kind/bug"]
 body:
   - type: markdown
     attributes:
@@ -45,7 +45,7 @@ body:
       description: use `sealer version`
       placeholder: ex. {"gitVersion":"v0.8.5","gitCommit":"f9c3d99","buildDate":"2022-04-28 14:16:58","goVersion":"go1.16.15","compiler":"gc","platform":"linux/amd64"}
     validations:
-      required: true
+      required: false
   - type: input
     id: os
     attributes:
@@ -53,7 +53,7 @@ body:
       description: e.g `cat /etc/os-release`
       placeholder: ex. Ubuntu 16.04
     validations:
-      required: true
+      required: false
   - type: input
     id: kernel
     attributes:


### PR DESCRIPTION
…kind/bug and the OS and Kernel field will not be required.

Signed-off-by: starComingup <1225067236@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
In recently bug-report issues, we find the label kind/bug can't show after user commit a new issue, so we modify the issue-template label.
Another purpose is that the OS/Kernel field don't need in some scenario, so i cancel requirement check in the pr.

### Does this pull request fix one issue?
NONE

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
NONE

### Describe how to verify it
NONE

### Special notes for reviews
NONE