### PR TITLE
chore: add github action for writing release draft automatically

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,39 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+version-template: $MAJOR.$MINOR.$PATCH
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'kind/feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'kind/bug'
+  - title: 📝 Documentation updates
+    labels:
+      - 'documentation'
+      - 'kind/documentation'
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - dependencies
+      - 'kind/cleanup'
+  - title: 🚦 Tests
+    labels: 
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+change-template: '* $TITLE (#$NUMBER) @$AUTHOR'
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,18 @@ jobs:
           echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
         working-directory: src/github.com/sealerio/sealer
 
+      - uses: release-drafter/release-drafter@v5
+        name: create release drafter
+        id: drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: write release draft to file
+        shell: bash
+        working-directory: src/github.com/sealerio/sealer
+        run: |
+          echo "${{steps.drafter.outputs.body}}" >> release_note.md
+
       - name: Note
         id: Note
         env:
@@ -39,6 +51,7 @@ jobs:
         with:
           name: sealer-release-notes
           path: src/github.com/sealerio/sealer/release_note.md
+
   build:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
@@ -105,7 +118,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_unmatched_files: true
           name: sealer ${{ needs.note.outputs.stringver }}
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
           body_path: ./builds/sealer-release-notes/release_note.md
           files: |


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Currently, we manually write the release draft every time when we do version release works, which is consume much times.

and this github action will distinguish different pull request types via labels, and write release draft automatically.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE

### Describe how you did it

add github action named "release-drafter/release-drafter" to write release draft automatically.

### Describe how to verify it


### Special notes for reviews
