### PR TITLE
Bugfix: filter the empty string to make sure the cluster node ip is valid

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -77,7 +77,7 @@ func validateArgs(runArgs *Args) error {
 
 	// validate input nodes IP info
 	if len(runArgs.Nodes) != 0 {
-		// empty runArgs.Nodes is valid, since no nodes are input.
+		// empty runArgs.Nodes are valid, since no nodes are input.
 		if err := validateIPStr(runArgs.Nodes); err != nil {
 			errMsg = append(errMsg, err.Error())
 		}
@@ -127,13 +127,17 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 		})
 	}
 
+	// if inNodes is empty,Split will return a slice of length 1 whose only element is inNodes.
+	// so we need to filter the empty string to make sure the cluster node ip is valid.
 	nodes := strings.Split(inNodes, ",")
 	nodeHosts := make([]v2.Host, len(nodes))
 	for _, node := range nodes {
-		nodeHosts = append(nodeHosts, v2.Host{
-			IPS:   []string{node},
-			Roles: []string{common.NODE},
-		})
+		if node != "" {
+			nodeHosts = append(nodeHosts, v2.Host{
+				IPS:   []string{node},
+				Roles: []string{common.NODE},
+			})
+		}
 	}
 
 	result := make([]v2.Host, len(masters)+len(nodes))

--- a/cmd/sealer/cmd/run.go
+++ b/cmd/sealer/cmd/run.go
@@ -15,8 +15,9 @@
 package cmd
 
 import (
-	"github.com/sealerio/sealer/utils/net"
 	"os"
+
+	"github.com/sealerio/sealer/utils/net"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"

--- a/cmd/sealer/cmd/run.go
+++ b/cmd/sealer/cmd/run.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"github.com/sealerio/sealer/utils/net"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -52,6 +53,17 @@ create a cluster with custom environment variables:
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// set local ip address as master0 default ip if user input is empty.
+		// this is convenient to execute `sealer run` without set many arguments.
+		// Example looks like "sealer run kubernetes:v1.19.8"
+		if runArgs.Masters == "" {
+			ip, err := net.GetLocalDefaultIP()
+			if err != nil {
+				return err
+			}
+			runArgs.Masters = ip
+		}
+
 		applier, err := apply.NewApplierFromArgs(args[0], runArgs)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

1. filter the empty string to make sure the cluster node ip is valid.
2. set local ip address as master0 default ip if user input is empty.

### Describe how to verify it

run clusterImage without set IP address and auth info to see if it is success.

`sealer run kubernetes:v1.19.8`

### Special notes for reviews
