### PR TITLE
feat: add a field to distinguish runtime tool and add TestLoadMetadata unit test.

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -43,7 +43,17 @@ type Metadata struct {
 	//KubeVersion is a SemVer constraint specifying the version of Kubernetes required.
 	KubeVersion string `json:"kubeVersion"`
 	NydusFlag   bool   `json:"NydusFlag"`
+	//ClusterRuntime is a flag to distinguish the runtime for k0s、k8s、k3s
+	ClusterRuntime ClusterRuntime `json:"ClusterRuntime"`
 }
+
+type ClusterRuntime string
+
+const (
+	K0s ClusterRuntime = "k0s"
+	K3s ClusterRuntime = "k3s"
+	K8s ClusterRuntime = "k8s"
+)
 
 type KubeadmRuntime struct {
 	*sync.Mutex

--- a/pkg/runtime/utils_test.go
+++ b/pkg/runtime/utils_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+const (
+	mockMetadata = `{
+  "version": "v1.19.8",
+  "arch": "amd64",
+  "ClusterRuntime": "k8s",
+  "NydusFlag": false,
+  "kubeVersion": "",
+  "variant": ""
+}
+`
+)
+
+func TestLoadMetadata(t *testing.T) {
+	const (
+		rootfsPath       = "rootfs"
+		metadataFileName = "Metadata"
+	)
+	type object struct {
+		RuntimeMetadata []byte
+	}
+	tests := []struct {
+		name    string
+		object  object
+		want    *Metadata
+		wantErr bool
+	}{
+		{
+			name: "test metadata file from rootfs",
+			object: object{
+				[]byte(mockMetadata),
+			},
+			want: &Metadata{
+				Version:        "v1.19.8",
+				Arch:           "amd64",
+				ClusterRuntime: K8s,
+				NydusFlag:      false,
+				KubeVersion:    "",
+				Variant:        "",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//prevent the read permission denied.
+			oldmask := syscall.Umask(0)
+			defer syscall.Umask(oldmask)
+
+			dir, err := os.MkdirTemp("", "test-rootfs-metadata-tmp")
+			if err != nil {
+				t.Errorf("Make temp dir %s error = %s, wantErr %v", dir, err, tt.wantErr)
+			}
+			defer func() {
+				err = os.RemoveAll(dir)
+				if err != nil {
+					t.Errorf("Remove temp dir %s error = %v, wantErr %v", dir, err, tt.wantErr)
+				}
+			}()
+
+			err = os.Mkdir(filepath.Join(dir, rootfsPath), 0777)
+			if err != nil {
+				t.Errorf("Make dir %s error = %s, wantErr %v", dir, err, tt.wantErr)
+			}
+
+			err = ioutil.WriteFile(filepath.Join(dir, rootfsPath, metadataFileName), tt.object.RuntimeMetadata, 0777)
+			if err != nil {
+				t.Errorf("Write file %s error = %v, wantErr %v", filepath.Join(dir, rootfsPath, metadataFileName), err, tt.wantErr)
+			}
+
+			metadata, err := LoadMetadata(filepath.Join(dir, rootfsPath))
+			if err != nil {
+				t.Errorf("LoadMetadata error: %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(metadata, tt.want) {
+				t.Errorf("Metadata loaded from file is not wanted! Got: %v, wanted: %v", metadata, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: starComingup <1225067236@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
We need a field to distinguish k0s、k3s、k8s runtime tool.

### Does this pull request fix one issue?
Fixed #1549 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add a field in runtime Metadata struct.

### Describe how to verify it
```
root@ecs-66c3:~/go/src/github.com/sealerio/sealer# go test -v -run TestLoadMetadata ./pkg/runtime/
=== RUN   TestLoadMetadata
=== RUN   TestLoadMetadata/test_metadata_file_from_rootfs
--- PASS: TestLoadMetadata (0.00s)
    --- PASS: TestLoadMetadata/test_metadata_file_from_rootfs (0.00s)
PASS
ok  	github.com/sealerio/sealer/pkg/runtime	0.011s
```

### Special notes for reviews
NONE