### PR TITLE
refactor: use net.IP after dealing IP string in validation

### DIFF
--- a/apply/applydriver/local.go
+++ b/apply/applydriver/local.go
@@ -16,6 +16,7 @@ package applydriver
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/sealerio/sealer/apply/processor"
 	"github.com/sealerio/sealer/common"
@@ -159,7 +160,7 @@ func (c *Applier) reconcileCluster() error {
 	return c.scaleCluster(mj, md, nj, nd)
 }
 
-func (c *Applier) scaleCluster(mj, md, nj, nd []string) error {
+func (c *Applier) scaleCluster(mj, md, nj, nd []net.IP) error {
 	logrus.Info("Start to scale this cluster")
 	logrus.Debugf("current cluster: master %s, worker %s", c.ClusterCurrent.GetMasterIPList(), c.ClusterCurrent.GetNodeIPList())
 

--- a/apply/processor/delete.go
+++ b/apply/processor/delete.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sealerio/sealer/pkg/plugin"
 	"github.com/sealerio/sealer/pkg/runtime"
 	v2 "github.com/sealerio/sealer/types/api/v2"
-	"github.com/sealerio/sealer/utils/strings"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 )
 
 type DeleteProcessor struct {
@@ -66,7 +66,7 @@ func (d *DeleteProcessor) GetPhasePluginFunc(phase plugin.Phase) func(cluster *v
 func (d *DeleteProcessor) UnMountRootfs(cluster *v2.Cluster) error {
 	hosts := append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
 	config := runtime.GetRegistryConfig(common.DefaultTheClusterRootfsDir(cluster.Name), cluster.GetMaster0IP())
-	if strings.NotIn(config.IP, hosts) {
+	if utilsnet.NotInIPList(config.IP, hosts) {
 		hosts = append(hosts, config.IP)
 	}
 	fs, err := filesystem.NewFilesystem(common.DefaultTheClusterRootfsDir(cluster.Name))

--- a/apply/processor/scale.go
+++ b/apply/processor/scale.go
@@ -16,15 +16,14 @@ package processor
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	"github.com/sealerio/sealer/pkg/config"
-	"github.com/sealerio/sealer/pkg/plugin"
-
-	"github.com/sealerio/sealer/pkg/filesystem/cloudfilesystem"
-
 	"github.com/sealerio/sealer/pkg/filesystem"
+	"github.com/sealerio/sealer/pkg/filesystem/cloudfilesystem"
+	"github.com/sealerio/sealer/pkg/plugin"
 	"github.com/sealerio/sealer/pkg/runtime"
 	v2 "github.com/sealerio/sealer/types/api/v2"
 )
@@ -36,10 +35,10 @@ type ScaleProcessor struct {
 	KubeadmConfig   *runtime.KubeadmConfig
 	Config          config.Interface
 	Plugins         plugin.Plugins
-	MastersToJoin   []string
-	MastersToDelete []string
-	NodesToJoin     []string
-	NodesToDelete   []string
+	MastersToJoin   []net.IP
+	MastersToDelete []net.IP
+	NodesToJoin     []net.IP
+	NodesToDelete   []net.IP
 	IsScaleUp       bool
 }
 
@@ -126,7 +125,7 @@ func (s *ScaleProcessor) Delete(cluster *v2.Cluster) error {
 	return s.Runtime.DeleteNodes(s.NodesToDelete)
 }
 
-func NewScaleProcessor(kubeadmConfig *runtime.KubeadmConfig, clusterFile clusterfile.Interface, masterToJoin, masterToDelete, nodeToJoin, nodeToDelete []string) (Processor, error) {
+func NewScaleProcessor(kubeadmConfig *runtime.KubeadmConfig, clusterFile clusterfile.Interface, masterToJoin, masterToDelete, nodeToJoin, nodeToDelete []net.IP) (Processor, error) {
 	fs, err := filesystem.NewFilesystem(common.DefaultTheClusterRootfsDir(clusterFile.GetCluster().Name))
 	if err != nil {
 		return nil, err

--- a/apply/run.go
+++ b/apply/run.go
@@ -16,6 +16,7 @@ package apply
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -23,7 +24,7 @@ import (
 	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
-	"github.com/sealerio/sealer/utils/net"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 )
 
 func ConstructClusterFromArg(imageName string, runArgs *Args) (*v2.Cluster, error) {
@@ -96,14 +97,14 @@ func validateArgs(runArgs *Args) error {
 func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 	var err error
 	if isRange(inMasters) {
-		inMasters, err = net.IPRangeToList(inMasters)
+		inMasters, err = utilsnet.IPRangeToList(inMasters)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	if isRange(inNodes) {
-		if inNodes, err = net.IPRangeToList(inNodes); err != nil {
+		if inNodes, err = utilsnet.IPRangeToList(inNodes); err != nil {
 			return nil, err
 		}
 	}
@@ -114,7 +115,9 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 		if index == 0 {
 			// only master0 should add two roles: master and master0
 			masterHosts = append(masterHosts, v2.Host{
-				IPS:   []string{master},
+				IPS: []net.IP{
+					net.ParseIP(master),
+				},
 				Roles: []string{common.MASTER, common.MASTER0},
 			})
 
@@ -122,7 +125,9 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 		}
 
 		masterHosts = append(masterHosts, v2.Host{
-			IPS:   []string{master},
+			IPS: []net.IP{
+				net.ParseIP(master),
+			},
 			Roles: []string{common.MASTER},
 		})
 	}
@@ -134,7 +139,7 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 	for _, node := range nodes {
 		if node != "" {
 			nodeHosts = append(nodeHosts, v2.Host{
-				IPS:   []string{node},
+				IPS:   []net.IP{net.ParseIP(node)},
 				Roles: []string{common.NODE},
 			})
 		}

--- a/apply/scale_test.go
+++ b/apply/scale_test.go
@@ -16,6 +16,7 @@ package apply
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/sealerio/sealer/common"
@@ -104,32 +105,32 @@ func TestNewCleanApplierFromArgs(t *testing.T) {
 func Test_returnFilteredIPList(t *testing.T) {
 	tests := []struct {
 		name              string
-		clusterIPList     []string
-		toBeDeletedIPList []string
+		clusterIPList     []net.IP
+		toBeDeletedIPList []net.IP
 		wantErr           bool
 	}{
 		{
 			"test",
-			[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4"},
-			[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4"},
+			[]net.IP{net.ParseIP("10.10.10.1"), net.ParseIP("10.10.10.2"), net.ParseIP("10.10.10.3"), net.ParseIP("10.10.10.4")},
+			[]net.IP{net.ParseIP("10.10.10.1"), net.ParseIP("10.10.10.2"), net.ParseIP("10.10.10.3"), net.ParseIP("10.10.10.4")},
 			false,
 		},
 		{
 			"test1",
-			[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4"},
-			[]string{},
+			[]net.IP{net.ParseIP("10.10.10.1"), net.ParseIP("10.10.10.2"), net.ParseIP("10.10.10.3"), net.ParseIP("10.10.10.4")},
+			[]net.IP{},
 			false,
 		},
 		{
 			"test2",
-			[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4"},
-			[]string{"10.10.10.4"},
+			[]net.IP{net.ParseIP("10.10.10.1"), net.ParseIP("10.10.10.2"), net.ParseIP("10.10.10.3"), net.ParseIP("10.10.10.4")},
+			[]net.IP{net.ParseIP("10.10.10.4")},
 			false,
 		},
 		{
 			"test3",
-			[]string{},
-			[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "10.10.10.4"},
+			[]net.IP{},
+			[]net.IP{net.ParseIP("10.10.10.1"), net.ParseIP("10.10.10.2"), net.ParseIP("10.10.10.3"), net.ParseIP("10.10.10.4")},
 			false,
 		},
 	}

--- a/cmd/seautil/cmd/certs.go
+++ b/cmd/seautil/cmd/certs.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"os"
+	"fmt"
+	"net"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/sealerio/sealer/pkg/cert"
@@ -40,12 +40,12 @@ var certsCmd = &cobra.Command{
 	Use:   "certs",
 	Short: "generate kubernetes certs",
 	Long:  `seautil cert --node-ip 192.168.0.2 --node-name master1 --dns-domain aliyun.com --alt-names aliyun.local`,
-	Run: func(cmd *cobra.Command, args []string) {
-		err := cert.GenerateCert(config.CertPath, config.CertEtcdPath, config.AltNames, config.NodeIP, config.NodeName, config.ServiceCIDR, config.DNSDomain)
-		if err != nil {
-			logrus.Error(err)
-			os.Exit(-1)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nodeIP := net.ParseIP(config.NodeIP)
+		if nodeIP == nil {
+			return fmt.Errorf("input --node-ip(%s) is an invalid IP format", config.NodeIP)
 		}
+		return cert.GenerateCert(config.CertPath, config.CertEtcdPath, config.AltNames, nodeIP, config.NodeName, config.ServiceCIDR, config.DNSDomain)
 	},
 }
 

--- a/cmd/seautil/cmd/route.go
+++ b/cmd/seautil/cmd/route.go
@@ -15,7 +15,10 @@
 package cmd
 
 import (
-	"github.com/sealerio/sealer/utils/net"
+	"fmt"
+	"net"
+
+	utilsnet "github.com/sealerio/sealer/utils/net"
 
 	"github.com/spf13/cobra"
 )
@@ -45,7 +48,11 @@ func RouteCheckCmd() *cobra.Command {
 		Short: "A brief description of your command",
 		Long:  `seautil route check --host 192.168.56.3`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return net.CheckIsDefaultRoute(routeFlag.host)
+			host := net.ParseIP(routeFlag.host)
+			if host == nil {
+				return fmt.Errorf("input host(%s) is invalid: it should be an IP format", routeFlag.host)
+			}
+			return utilsnet.CheckIsDefaultRoute(host)
 		},
 	}
 	checkCmd.Flags().StringVar(&routeFlag.host, "host", "", "check host ip address is default iFace")
@@ -58,7 +65,16 @@ func RouteAddCmd() *cobra.Command {
 		Short: "A brief description of your command",
 		Long:  `seautil route add --host 192.168.0.2 --gateway 10.0.0.2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := net.NewRouter(routeFlag.host, routeFlag.gatewayIP)
+			host := net.ParseIP(routeFlag.host)
+			if host == nil {
+				return fmt.Errorf("input host(%s) is invalid: it must be an IP format", routeFlag.host)
+			}
+
+			gateway := net.ParseIP(routeFlag.gatewayIP)
+			if gateway == nil {
+				return fmt.Errorf("input gateway(%s) is invalid: it must be an IP format", routeFlag.gatewayIP)
+			}
+			r := utilsnet.NewRouter(host, gateway)
 			return r.SetRoute()
 		},
 	}
@@ -73,7 +89,17 @@ func RouteDelCmd() *cobra.Command {
 		Short: "delete router",
 		Long:  `seautil route del --host 192.168.0.2 --gateway 10.0.0.2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			r := net.NewRouter(routeFlag.host, routeFlag.gatewayIP)
+			host := net.ParseIP(routeFlag.host)
+			if host == nil {
+				return fmt.Errorf("input host(%s) is invalid: it must be an IP format", routeFlag.host)
+			}
+
+			gateway := net.ParseIP(routeFlag.gatewayIP)
+			if gateway == nil {
+				return fmt.Errorf("input gateway(%s) is invalid: it must be an IP format", routeFlag.gatewayIP)
+			}
+
+			r := utilsnet.NewRouter(host, gateway)
 			return r.DelRoute()
 		},
 	}

--- a/pkg/cert/cert_cmd.go
+++ b/pkg/cert/cert_cmd.go
@@ -16,6 +16,7 @@ package cert
 
 import (
 	"fmt"
+	"net"
 )
 
 // CMD return sealer cert command
@@ -47,7 +48,7 @@ func CMD(altNames []string, hostIP, hostName, serviceCIRD, DNSDomain string) str
 }
 
 // GenerateCert generate all cert.
-func GenerateCert(certPATH, certEtcdPATH string, altNames []string, hostIP, hostName, serviceCIRD, DNSDomain string) error {
+func GenerateCert(certPATH, certEtcdPATH string, altNames []string, hostIP net.IP, hostName, serviceCIRD, DNSDomain string) error {
 	certConfig, err := NewMetaData(certPATH, certEtcdPATH, altNames, serviceCIRD, hostName, hostIP, DNSDomain)
 	if err != nil {
 		return fmt.Errorf("generator cert config failed %v", err)

--- a/pkg/cert/kube_certs.go
+++ b/pkg/cert/kube_certs.go
@@ -172,7 +172,7 @@ func certList(CertPath, CertEtcdPath string) []Config {
 type MetaData struct {
 	APIServer    AltNames
 	NodeName     string
-	NodeIP       string
+	NodeIP       net.IP
 	DNSDomain    string
 	CertPath     string
 	CertEtcdPath string
@@ -189,7 +189,7 @@ const (
 )
 
 // NewMetaData apiServerIPAndDomains = MasterIP + VIP + CertSANS 暂时只有apiserver, 记得把cluster.local后缀加到apiServerIPAndDOmas里先
-func NewMetaData(certPATH, certEtcdPATH string, apiServerIPAndDomains []string, SvcCIDR, nodeName, nodeIP, DNSDomain string) (*MetaData, error) {
+func NewMetaData(certPATH, certEtcdPATH string, apiServerIPAndDomains []string, SvcCIDR, nodeName string, nodeIP net.IP, DNSDomain string) (*MetaData, error) {
 	data := &MetaData{}
 	data.CertPath = certPATH
 	data.CertEtcdPath = certEtcdPATH
@@ -215,8 +215,8 @@ func NewMetaData(certPATH, certEtcdPATH string, apiServerIPAndDomains []string, 
 		data.APIServer.DNSNames[altName] = altName
 	}
 
-	if ip := net.ParseIP(nodeIP); ip != nil {
-		data.APIServer.IPs[ip.String()] = ip
+	if nodeIP != nil {
+		data.APIServer.IPs[nodeIP.String()] = nodeIP
 	}
 
 	data.NodeIP = nodeIP
@@ -246,9 +246,9 @@ func (meta *MetaData) etcdAltAndCommonName(certList *[]Config) {
 			meta.NodeName: meta.NodeName,
 		},
 		IPs: map[string]net.IP{
-			net.IPv4(127, 0, 0, 1).String():         net.IPv4(127, 0, 0, 1),
-			net.ParseIP(meta.NodeIP).To4().String(): net.ParseIP(meta.NodeIP).To4(),
-			net.IPv6loopback.String():               net.IPv6loopback,
+			net.IPv4(127, 0, 0, 1).String(): net.IPv4(127, 0, 0, 1),
+			meta.NodeIP.To4().String():      meta.NodeIP.To4(),
+			net.IPv6loopback.String():       net.IPv6loopback,
 		},
 	}
 	(*certList)[EtcdServerCert].CommonName = meta.NodeName

--- a/pkg/cert/kube_certs_test.go
+++ b/pkg/cert/kube_certs_test.go
@@ -15,6 +15,7 @@
 package cert
 
 import (
+	"net"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestGenerateAll(t *testing.T) {
 			false,
 		},
 	}
-	certMeta, err := NewMetaData(BasePath, EtcdBasePath, []string{"test.com", "192.168.1.2", "kubernetes.default.svc.sealyun"}, "10.64.0.0/10", "master1", "172.27.139.11", "cluster.local")
+	certMeta, err := NewMetaData(BasePath, EtcdBasePath, []string{"test.com", "192.168.1.2", "kubernetes.default.svc.sealyun"}, "10.64.0.0/10", "master1", net.ParseIP("172.27.139.11"), "cluster.local")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/checker/host_checker.go
+++ b/pkg/checker/host_checker.go
@@ -16,6 +16,7 @@ package checker
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -28,7 +29,7 @@ type HostChecker struct {
 }
 
 func (a HostChecker) Check(cluster *v2.Cluster, phase string) error {
-	var ipList []string
+	var ipList []net.IP
 	for _, hosts := range cluster.Spec.Hosts {
 		ipList = append(ipList, hosts.IPS...)
 	}
@@ -43,7 +44,7 @@ func NewHostChecker() Interface {
 	return &HostChecker{}
 }
 
-func checkHostnameUnique(cluster *v2.Cluster, ipList []string) error {
+func checkHostnameUnique(cluster *v2.Cluster, ipList []net.IP) error {
 	hostnameList := map[string]bool{}
 	for _, ip := range ipList {
 		s, err := ssh.GetHostSSHClient(ip, cluster)
@@ -63,7 +64,7 @@ func checkHostnameUnique(cluster *v2.Cluster, ipList []string) error {
 }
 
 //Check whether the node time is synchronized
-func checkTimeSync(cluster *v2.Cluster, ipList []string) error {
+func checkTimeSync(cluster *v2.Cluster, ipList []net.IP) error {
 	for _, ip := range ipList {
 		s, err := ssh.GetHostSSHClient(ip, cluster)
 		if err != nil {

--- a/pkg/client/k8s/client.go
+++ b/pkg/client/k8s/client.go
@@ -16,6 +16,7 @@ package k8s
 
 import (
 	"context"
+	"net"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -109,8 +110,8 @@ func (c *Client) ListNodesByLabel(label string) (*v1.NodeList, error) {
 	return nodes, nil
 }
 
-func (c *Client) ListNodeIPByLabel(label string) ([]string, error) {
-	var ips []string
+func (c *Client) ListNodeIPByLabel(label string) ([]net.IP, error) {
+	var ips []net.IP
 	nodes, err := c.ListNodesByLabel(label)
 	if err != nil {
 		return nil, err
@@ -118,7 +119,7 @@ func (c *Client) ListNodeIPByLabel(label string) ([]string, error) {
 	for _, node := range nodes.Items {
 		for _, v := range node.Status.Addresses {
 			if v.Type == v1.NodeInternalIP {
-				ips = append(ips, v.Address)
+				ips = append(ips, net.ParseIP(v.Address))
 			}
 		}
 	}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -15,6 +15,7 @@
 package env
 
 import (
+	"net"
 	"reflect"
 	"testing"
 
@@ -53,7 +54,7 @@ func getTestCluster() *v2.Cluster {
 			Env:   []string{"IP=127.0.0.1", "key=value"},
 			Hosts: []v2.Host{
 				{
-					IPS:   []string{"192.168.0.2", "192.168.0.3", "192.168.0.4"},
+					IPS:   []net.IP{net.ParseIP("192.168.0.2"), net.ParseIP("192.168.0.3"), net.ParseIP("192.168.0.4")},
 					Roles: []string{"master"},
 					Env:   []string{"key=bar", "key=foo", "foo=bar", "IP=127.0.0.2"},
 				},
@@ -105,7 +106,7 @@ func Test_processor_RenderAll(t *testing.T) {
 		Cluster *v2.Cluster
 	}
 	type args struct {
-		host string
+		host net.IP
 		dir  string
 	}
 	tests := []struct {
@@ -118,7 +119,7 @@ func Test_processor_RenderAll(t *testing.T) {
 			"test render dir",
 			fields{getTestCluster()},
 			args{
-				host: "192.168.0.2",
+				host: net.ParseIP("192.168.0.2"),
 				dir:  "test/template",
 			},
 			false,

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/sealerio/sealer/common"
@@ -29,7 +30,7 @@ import (
 
 type Exec struct {
 	cluster *v2.Cluster
-	ipList  []string
+	ipList  []net.IP
 }
 
 func NewExecCmd(clusterName string, roles string) (Exec, error) {
@@ -45,7 +46,7 @@ func NewExecCmd(clusterName string, roles string) (Exec, error) {
 	if err != nil {
 		return Exec{}, err
 	}
-	var ipList []string
+	var ipList []net.IP
 	if roles == "" {
 		ipList = append(cluster.GetMasterIPList(), cluster.GetNodeIPList()...)
 	} else {

--- a/pkg/filesystem/cloudfilesystem/cloudfilesystem.go
+++ b/pkg/filesystem/cloudfilesystem/cloudfilesystem.go
@@ -15,12 +15,14 @@
 package cloudfilesystem
 
 import (
+	"net"
+
 	v2 "github.com/sealerio/sealer/types/api/v2"
 )
 
 type Interface interface {
 	// MountRootfs :send cloud rootfs to all hosts.
-	MountRootfs(cluster *v2.Cluster, hosts []string, initFlag bool) error
+	MountRootfs(cluster *v2.Cluster, hosts []net.IP, initFlag bool) error
 	// UnMountRootfs :umount rootfs on all hosts.
-	UnMountRootfs(cluster *v2.Cluster, hosts []string) error
+	UnMountRootfs(cluster *v2.Cluster, hosts []net.IP) error
 }

--- a/pkg/filesystem/cloudfilesystem/utils.go
+++ b/pkg/filesystem/cloudfilesystem/utils.go
@@ -17,6 +17,7 @@ package cloudfilesystem
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/utils/os/fs"
@@ -28,7 +29,7 @@ import (
 	"github.com/sealerio/sealer/utils/ssh"
 )
 
-func copyFiles(sshEntry ssh.Interface, ip, src, target string) error {
+func copyFiles(sshEntry ssh.Interface, ip net.IP, src, target string) error {
 	files, err := ioutil.ReadDir(src)
 	if err != nil {
 		return fmt.Errorf("failed to copy files %s", err)
@@ -46,7 +47,7 @@ func copyFiles(sshEntry ssh.Interface, ip, src, target string) error {
 	return nil
 }
 
-func copyRegistry(regIP string, cluster *v2.Cluster, mountDir map[string]bool, target string) error {
+func copyRegistry(regIP net.IP, cluster *v2.Cluster, mountDir map[string]bool, target string) error {
 	sshClient, err := ssh.GetHostSSHClient(regIP, cluster)
 	if err != nil {
 		return err

--- a/pkg/filesystem/clusterimage/clusterimage.go
+++ b/pkg/filesystem/clusterimage/clusterimage.go
@@ -17,6 +17,7 @@ package clusterimage
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path/filepath"
 	"time"
 
@@ -133,7 +134,7 @@ func (m *mounter) mountImage(cluster *v2.Cluster) error {
 	return nil
 }
 
-func renderENV(imageMountDir string, ipList []string, p env.Interface) error {
+func renderENV(imageMountDir string, ipList []net.IP, p env.Interface) error {
 	var (
 		renderEtc       = filepath.Join(imageMountDir, common.EtcDir)
 		renderChart     = filepath.Join(imageMountDir, common.RenderChartsDir)

--- a/pkg/infra/aliyun/ali_ecs.go
+++ b/pkg/infra/aliyun/ali_ecs.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	"github.com/sealerio/sealer/utils"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	strUtils "github.com/sealerio/sealer/utils/strings"
 )
 
@@ -300,7 +301,8 @@ func (a *AliProvider) ReconcileInstances(instanceRole string) error {
 		if err != nil {
 			return err
 		}
-		hosts.IPList = strUtils.NewComparator(hosts.IPList, ipList).GetUnion()
+		IPStrList := utilsnet.IPsToIPStrs(hosts.IPList)
+		hosts.IPList = utilsnet.IPStrsToIPs(strUtils.NewComparator(IPStrList, ipList).GetUnion())
 		logrus.Infof("get scale up IP list %v, append iplist %v, host count %s", ipList, hosts.IPList, hosts.Count)
 	} else if len(instances) > i {
 		var deleteInstancesIDs []string
@@ -327,7 +329,8 @@ func (a *AliProvider) ReconcileInstances(instanceRole string) error {
 		if err != nil {
 			return err
 		}
-		hosts.IPList = strUtils.NewComparator(hosts.IPList, ipList).GetIntersection()
+		IPStrList := utilsnet.IPsToIPStrs(hosts.IPList)
+		hosts.IPList = utilsnet.IPStrsToIPs(strUtils.NewComparator(IPStrList, ipList).GetIntersection())
 	}
 
 	cpu, err := strconv.Atoi(hosts.CPU)

--- a/pkg/infra/container/utils.go
+++ b/pkg/infra/container/utils.go
@@ -17,6 +17,7 @@ package container
 import (
 	"crypto/rand"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -32,9 +33,9 @@ func IsDockerAvailable() bool {
 	return strings.Contains(lines, "docker version")
 }
 
-func getDiff(host v1.Hosts) (int, []string, error) {
+func getDiff(host v1.Hosts) (int, []net.IP, error) {
 	var num int
-	var iplist []string
+	var iplist []net.IP
 	count, err := strconv.Atoi(host.Count)
 	if err != nil {
 		return 0, nil, err

--- a/pkg/ipvs/ipvs.go
+++ b/pkg/ipvs/ipvs.go
@@ -15,7 +15,7 @@
 package ipvs
 
 import (
-	"strings"
+	"net"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -32,20 +32,17 @@ const (
 )
 
 // LvsStaticPodYaml return lvs care static pod yaml
-func LvsStaticPodYaml(vip string, masters []string, image string) string {
-	if vip == "" || len(masters) == 0 {
+func LvsStaticPodYaml(vip net.IP, masters []net.IP, image string) string {
+	if vip == nil || len(masters) == 0 {
 		return ""
 	}
 	if image == "" {
 		image = DefaultLvsCareImage
 	}
-	args := []string{"care", "--vs", vip + ":6443", "--health-path", "/healthz", "--health-schem", "https"}
+	args := []string{"care", "--vs", vip.String() + ":6443", "--health-path", "/healthz", "--health-schem", "https"}
 	for _, m := range masters {
-		if strings.Contains(m, ":") {
-			m = strings.Split(m, ":")[0]
-		}
 		args = append(args, "--rs")
-		args = append(args, m+":6443")
+		args = append(args, m.String()+":6443")
 	}
 	flag := true
 	pod := componentPod(v1.Container{

--- a/pkg/plugin/labels.go
+++ b/pkg/plugin/labels.go
@@ -16,10 +16,11 @@ package plugin
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/sealerio/sealer/pkg/client/k8s"
-	strUtils "github.com/sealerio/sealer/utils/strings"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 )
@@ -78,7 +79,7 @@ func (l LabelsNodes) Run(context Context, phase Phase) error {
 	return nil
 }
 
-func (l LabelsNodes) formatData(data string, hosts []string) map[string][]label {
+func (l LabelsNodes) formatData(data string, hosts []net.IP) map[string][]label {
 	m := make(map[string][]label)
 	items := strings.Split(data, "\n")
 	if len(items) == 0 {
@@ -92,7 +93,7 @@ func (l LabelsNodes) formatData(data string, hosts []string) map[string][]label 
 			continue
 		}
 		ip := tmps[0]
-		if strUtils.NotIn(ip, hosts) {
+		if utilsnet.NotInIPList(net.ParseIP(ip), hosts) {
 			continue
 		}
 		labelStr := strings.Split(tmps[1], ",")

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -15,6 +15,8 @@
 package plugin
 
 import (
+	"net"
+
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
 )
@@ -57,5 +59,5 @@ const (
 type Context struct {
 	Plugin  *v1.Plugin
 	Cluster *v2.Cluster
-	Host    []string
+	Host    []net.IP
 }

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"plugin"
@@ -43,7 +44,7 @@ func (err InvalidPluginTypeError) Error() string {
 
 type Plugins interface {
 	Load() error
-	Run(host []string, phase Phase) error
+	Run(host []net.IP, phase Phase) error
 }
 
 // PluginsProcessor : process two list: plugin config list and embed pluginFactories that contains plugin interface.
@@ -104,7 +105,7 @@ func (c *PluginsProcessor) Load() error {
 }
 
 // Run execute each in-tree or out-of-tree plugin by traversing the plugin list.
-func (c *PluginsProcessor) Run(host []string, phase Phase) error {
+func (c *PluginsProcessor) Run(host []net.IP, phase Phase) error {
 	for _, plug := range c.Plugins {
 		if strUtils.NotIn(string(phase), strings.Split(plug.Spec.Action, "|")) {
 			continue

--- a/pkg/plugin/shell_plugin.go
+++ b/pkg/plugin/shell_plugin.go
@@ -16,10 +16,12 @@ package plugin
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/env"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	"github.com/sealerio/sealer/utils/ssh"
 	strUtils "github.com/sealerio/sealer/utils/strings"
 
@@ -58,10 +60,10 @@ func (s Sheller) Run(context Context, phase Phase) (err error) {
 			return err
 		}
 	}
-	var runPluginIPList []string
+	var runPluginIPList []net.IP
 	for _, ip := range allHostIP {
 		//skip non-cluster nodes
-		if strUtils.NotIn(ip, context.Host) {
+		if utilsnet.NotInIPList(ip, context.Host) {
 			continue
 		}
 		envProcessor := env.NewEnvProcessor(context.Cluster)

--- a/pkg/plugin/shell_plugin_test.go
+++ b/pkg/plugin/shell_plugin_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"net"
 	"testing"
 
 	"github.com/sealerio/sealer/common"
@@ -47,7 +48,7 @@ func TestSheller_Run(t *testing.T) {
 	cluster.Spec.SSH.Passwd = "7758521"
 	cluster.Spec.Hosts = []typev2.Host{
 		{
-			IPS:   []string{"192.168.59.11"},
+			IPS:   []net.IP{net.ParseIP("192.168.59.11")},
 			Roles: []string{common.MASTER},
 		},
 	}

--- a/pkg/plugin/taint_plugin.go
+++ b/pkg/plugin/taint_plugin.go
@@ -16,10 +16,11 @@ package plugin
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/sealerio/sealer/pkg/client/k8s"
-	"github.com/sealerio/sealer/utils/net"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	strUtils "github.com/sealerio/sealer/utils/strings"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -84,7 +85,7 @@ func (l *Taint) Run(context Context, phase Phase) (err error) {
 	for _, n := range nodeList.Items {
 		node := n
 		for _, v := range node.Status.Addresses {
-			if strUtils.NotIn(v.Address, l.IPList) || strUtils.NotIn(v.Address, context.Host) {
+			if strUtils.NotIn(v.Address, l.IPList) || utilsnet.NotInIPList(net.ParseIP(v.Address), context.Host) {
 				continue
 			}
 			updateTaints := l.UpdateTaints(node.Spec.Taints, v.Address)
@@ -119,7 +120,7 @@ func (l *Taint) formatData(data string) error {
 			return fmt.Errorf("faild to split taint argument: %s", v)
 		}
 		ips := temps[0]
-		ipStr, err := net.AssemblyIPList(ips)
+		ipStr, err := utilsnet.AssemblyIPList(ips)
 		if err != nil {
 			return err
 		}

--- a/pkg/plugin/utils.go
+++ b/pkg/plugin/utils.go
@@ -16,11 +16,12 @@ package plugin
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	v1 "github.com/sealerio/sealer/types/api/v1"
 
-	"github.com/sealerio/sealer/utils/net"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	"github.com/sirupsen/logrus"
 
 	"github.com/sealerio/sealer/common"
@@ -34,7 +35,7 @@ const (
 	SplitSymbol = "|"
 )
 
-func GetIpsByOnField(on string, context Context, phase Phase) (ipList []string, err error) {
+func GetIpsByOnField(on string, context Context, phase Phase) (ipList []net.IP, err error) {
 	on = strings.TrimSpace(on)
 	if strings.Contains(on, EqualSymbol) {
 		if (phase != PhasePostInstall && phase != PhasePostJoin) && phase != PhasePreClean {
@@ -58,7 +59,7 @@ func GetIpsByOnField(on string, context Context, phase Phase) (ipList []string, 
 		}
 		ipList = ipList[:1]
 	} else {
-		ipList = net.DisassembleIPList(on)
+		ipList = utilsnet.DisassembleIPList(on)
 	}
 	if len(ipList) == 0 {
 		logrus.Debugf("node not found by on field [%s]", on)

--- a/pkg/runtime/kubeadm.go
+++ b/pkg/runtime/kubeadm.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -46,7 +47,7 @@ func (k *KubeadmRuntime) setKubeadmAPIVersion() {
 }
 
 // getCgroupDriverFromShell is get nodes container runtime CGroup by shell.
-func (k *KubeadmRuntime) getCgroupDriverFromShell(node string) (string, error) {
+func (k *KubeadmRuntime) getCgroupDriverFromShell(node net.IP) (string, error) {
 	var cmd string
 	if k.InitConfiguration.NodeRegistration.CRISocket == DefaultContainerdCRISocket {
 		cmd = ContainerdShell

--- a/pkg/runtime/kubeadm_types/v1beta2/types.go
+++ b/pkg/runtime/kubeadm_types/v1beta2/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta2
 
 import (
+	"net"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -192,7 +194,7 @@ type ClusterStatus struct {
 // APIEndpoint struct contains elements of API server instance deployed on a node.
 type APIEndpoint struct {
 	// AdvertiseAddress sets the IP address for the API server to advertise.
-	AdvertiseAddress string `json:"advertiseAddress,omitempty"`
+	AdvertiseAddress net.IP `json:"advertiseAddress,omitempty"`
 
 	// BindPort sets the secure port for the API Server to bind to.
 	// Defaults to 6443.

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/sealerio/sealer/utils/exec"
 
@@ -40,7 +41,7 @@ func (k *KubeadmRuntime) reset() error {
 	return k.DeleteRegistry()
 }
 
-func (k *KubeadmRuntime) resetNodes(nodes []string) {
+func (k *KubeadmRuntime) resetNodes(nodes []net.IP) {
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, node := range nodes {
 		node := node
@@ -56,7 +57,7 @@ func (k *KubeadmRuntime) resetNodes(nodes []string) {
 	}
 }
 
-func (k *KubeadmRuntime) resetMasters(nodes []string) {
+func (k *KubeadmRuntime) resetMasters(nodes []net.IP) {
 	for _, node := range nodes {
 		if err := k.resetNode(node); err != nil {
 			logrus.Errorf("delete master %s failed %v", node, err)
@@ -64,7 +65,7 @@ func (k *KubeadmRuntime) resetMasters(nodes []string) {
 	}
 }
 
-func (k *KubeadmRuntime) resetNode(node string) error {
+func (k *KubeadmRuntime) resetNode(node net.IP) error {
 	ssh, err := k.getHostSSHClient(node)
 	if err != nil {
 		return fmt.Errorf("reset node failed %v", err)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"fmt"
+	"net"
 	"sync"
 
 	v2 "github.com/sealerio/sealer/types/api/v2"
@@ -28,10 +29,10 @@ type Interface interface {
 	Init(cluster *v2.Cluster) error
 	Upgrade() error
 	Reset() error
-	JoinMasters(newMastersIPList []string) error
-	JoinNodes(newNodesIPList []string) error
-	DeleteMasters(mastersIPList []string) error
-	DeleteNodes(nodesIPList []string) error
+	JoinMasters(newMastersIPList []net.IP) error
+	JoinNodes(newNodesIPList []net.IP) error
+	DeleteMasters(mastersIPList []net.IP) error
+	DeleteNodes(nodesIPList []net.IP) error
 	GetClusterMetadata() (*Metadata, error)
 	UpdateCert(certs []string) error
 }
@@ -70,21 +71,21 @@ func (k *KubeadmRuntime) Reset() error {
 	return k.reset()
 }
 
-func (k *KubeadmRuntime) JoinMasters(newMastersIPList []string) error {
+func (k *KubeadmRuntime) JoinMasters(newMastersIPList []net.IP) error {
 	if len(newMastersIPList) != 0 {
 		logrus.Infof("%s will be added as master", newMastersIPList)
 	}
 	return k.joinMasters(newMastersIPList)
 }
 
-func (k *KubeadmRuntime) JoinNodes(newNodesIPList []string) error {
+func (k *KubeadmRuntime) JoinNodes(newNodesIPList []net.IP) error {
 	if len(newNodesIPList) != 0 {
 		logrus.Infof("%s will be added as worker", newNodesIPList)
 	}
 	return k.joinNodes(newNodesIPList)
 }
 
-func (k *KubeadmRuntime) DeleteMasters(mastersIPList []string) error {
+func (k *KubeadmRuntime) DeleteMasters(mastersIPList []net.IP) error {
 	if len(mastersIPList) != 0 {
 		logrus.Infof("master %s will be deleted", mastersIPList)
 		if err := k.confirmDeleteNodes(); err != nil {
@@ -94,7 +95,7 @@ func (k *KubeadmRuntime) DeleteMasters(mastersIPList []string) error {
 	return k.deleteMasters(mastersIPList)
 }
 
-func (k *KubeadmRuntime) DeleteNodes(nodesIPList []string) error {
+func (k *KubeadmRuntime) DeleteNodes(nodesIPList []net.IP) error {
 	if len(nodesIPList) != 0 {
 		logrus.Infof("worker %s will be deleted", nodesIPList)
 		if err := k.confirmDeleteNodes(); err != nil {

--- a/pkg/runtime/update_cert.go
+++ b/pkg/runtime/update_cert.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/client/k8s"
@@ -64,7 +65,7 @@ func (k *KubeadmRuntime) updateCert(certs []string) error {
 			return fmt.Errorf("failed to init master0 %v", err)
 		}
 	}
-	if err := k.SendJoinMasterKubeConfigs([]string{k.GetMaster0IP()}, AdminConf, ControllerConf, SchedulerConf, KubeletConf); err != nil {
+	if err := k.SendJoinMasterKubeConfigs([]net.IP{k.GetMaster0IP()}, AdminConf, ControllerConf, SchedulerConf, KubeletConf); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
 	"strings"
 )
@@ -49,7 +50,7 @@ func (k *KubeadmRuntime) upgrade() error {
 	return nil
 }
 
-func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binPath, version string) error {
+func (k *KubeadmRuntime) upgradeFirstMaster(IP net.IP, binPath, version string) error {
 	var drain string
 	//if version >= 1.20.x,add flag `--delete-emptydir-data`
 	if VersionCompare(version, V1200) {
@@ -73,7 +74,7 @@ func (k *KubeadmRuntime) upgradeFirstMaster(IP string, binPath, version string) 
 	return ssh.CmdAsync(IP, firstMasterCmds...)
 }
 
-func (k *KubeadmRuntime) upgradeOtherMasters(IPs []string, binpath, version string) error {
+func (k *KubeadmRuntime) upgradeOtherMasters(IPs []net.IP, binpath, version string) error {
 	var drain string
 	//if version >= 1.20.x,add flag `--delete-emptydir-data`
 	if VersionCompare(version, V1200) {
@@ -104,7 +105,7 @@ func (k *KubeadmRuntime) upgradeOtherMasters(IPs []string, binpath, version stri
 	return err
 }
 
-func (k *KubeadmRuntime) upgradeNodes(IPs []string, binpath string) error {
+func (k *KubeadmRuntime) upgradeNodes(IPs []net.IP, binpath string) error {
 	var nodeCmds = []string{
 		fmt.Sprintf(chmodCmd, binpath),
 		fmt.Sprintf(mvCmd, binpath),

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path"
 	"path/filepath"
 	"strings"
@@ -61,7 +62,7 @@ func VersionCompare(v1, v2 string) bool {
 	return true
 }
 
-func GetKubectlAndKubeconfig(ssh ssh.Interface, host, rootfs string) error {
+func GetKubectlAndKubeconfig(ssh ssh.Interface, host net.IP, rootfs string) error {
 	// fetch the cluster kubeconfig, and add /etc/hosts "EIP apiserver.cluster.local" so we can get the current cluster status later
 	err := ssh.Fetch(host, path.Join(common.DefaultKubeConfigDir(), "config"), common.KubeAdminConf)
 	if err != nil {
@@ -131,10 +132,10 @@ func GetClusterImagePlatform(rootfs string) (cp ocispecs.Platform) {
 	return
 }
 
-func RemoteCerts(altNames []string, hostIP, hostName, serviceCIRD, DNSDomain string) string {
+func RemoteCerts(altNames []string, hostIP net.IP, hostName, serviceCIRD, DNSDomain string) string {
 	cmd := "seautil certs "
-	if hostIP != "" {
-		cmd += fmt.Sprintf(" --node-ip %s", hostIP)
+	if hostIP != nil {
+		cmd += fmt.Sprintf(" --node-ip %s", hostIP.String())
 	}
 
 	if hostName != "" {

--- a/test/sealer_apply_test.go
+++ b/test/sealer_apply_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sealerio/sealer/test/suites/build"
 	"github.com/sealerio/sealer/test/testhelper"
 	"github.com/sealerio/sealer/test/testhelper/settings"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 )
 
 var _ = Describe("sealer apply", func() {
@@ -76,8 +77,10 @@ var _ = Describe("sealer apply", func() {
 					cluster = apply.CreateAliCloudInfraAndSave(cluster, tempFile)
 					//waiting for service to start
 					time.Sleep(10 * time.Second)
-					joinMasters := strings.Join(cluster.Spec.Masters.IPList[1:], ",")
-					joinNodes := strings.Join(cluster.Spec.Nodes.IPList[1:], ",")
+					joinMastersIPStrs := utilsnet.IPsToIPStrs(cluster.Spec.Masters.IPList[1:])
+					joinMasters := strings.Join(joinMastersIPStrs, ",")
+					joinNodesIPStrs := utilsnet.IPsToIPStrs(cluster.Spec.Nodes.IPList[1:])
+					joinNodes := strings.Join(joinNodesIPStrs, ",")
 					//sealer join master and node
 					apply.SendAndJoinCluster(sshClient, tempFile, joinMasters, joinNodes)
 					//add 3 masters and 3 nodes
@@ -135,7 +138,8 @@ var _ = Describe("sealer apply", func() {
 					usedCluster = apply.CreateAliCloudInfraAndSave(usedCluster, tempFile)
 					//waiting for service to start
 					time.Sleep(10 * time.Second)
-					joinNodes := strings.Join(usedCluster.Spec.Nodes.IPList[1:], ",")
+					joinNodesIPStrs := utilsnet.IPsToIPStrs(usedCluster.Spec.Nodes.IPList[1:])
+					joinNodes := strings.Join(joinNodesIPStrs, ",")
 					//sealer join master and node
 					apply.SendAndJoinCluster(sshClient, tempFile, "", joinNodes)
 					//add 3 masters and 3 nodes
@@ -200,8 +204,10 @@ var _ = Describe("sealer apply", func() {
 					cluster = apply.CreateAliCloudInfraAndSave(cluster, tempFile)
 					//waiting for service to start
 					time.Sleep(10 * time.Second)
-					joinMasters := strings.Join(cluster.Spec.Masters.IPList[1:], ",")
-					joinNodes := strings.Join(cluster.Spec.Nodes.IPList[1:], ",")
+					joinMastersIPStrs := utilsnet.IPsToIPStrs(cluster.Spec.Masters.IPList[1:])
+					joinMasters := strings.Join(joinMastersIPStrs, ",")
+					joinNodesIPStrs := utilsnet.IPsToIPStrs(cluster.Spec.Nodes.IPList[1:])
+					joinNodes := strings.Join(joinNodesIPStrs, ",")
 					//sealer join master and node
 					apply.SendAndJoinCluster(sshClient, tempFile, joinMasters, joinNodes)
 					//add 3 masters and 3 nodes

--- a/test/sealer_run_test.go
+++ b/test/sealer_run_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sealerio/sealer/test/suites/apply"
 	"github.com/sealerio/sealer/test/testhelper"
 	"github.com/sealerio/sealer/test/testhelper/settings"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 )
 
 var _ = Describe("sealer run", func() {
@@ -51,8 +52,10 @@ var _ = Describe("sealer run", func() {
 			}, settings.MaxWaiteTime)
 
 			By("start to init cluster", func() {
-				masters := strings.Join(usedCluster.Spec.Masters.IPList, ",")
-				nodes := strings.Join(usedCluster.Spec.Nodes.IPList, ",")
+				masterIPStrs := utilsnet.IPsToIPStrs(usedCluster.Spec.Masters.IPList)
+				masters := strings.Join(masterIPStrs, ",")
+				nodesIPStrs := utilsnet.IPsToIPStrs(usedCluster.Spec.Nodes.IPList)
+				nodes := strings.Join(nodesIPStrs, ",")
 				apply.SendAndRunCluster(sshClient, tempFile, masters, nodes, usedCluster.Spec.SSH.Passwd)
 				apply.CheckNodeNumWithSSH(sshClient, 2)
 			})

--- a/test/suites/apply/apply.go
+++ b/test/suites/apply/apply.go
@@ -17,6 +17,7 @@ package apply
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -273,7 +274,7 @@ func WaitAllNodeRunning() {
 	testhelper.CheckErr(err)
 }
 
-func WaitAllNodeRunningBySSH(s ssh.Interface, masterIP string) {
+func WaitAllNodeRunningBySSH(s ssh.Interface, masterIP net.IP) {
 	time.Sleep(30 * time.Second)
 	err := utils.Retry(10, 5*time.Second, func() error {
 		result, err := s.CmdToString(masterIP, "kubectl get nodes", "")

--- a/test/testhelper/utils.go
+++ b/test/testhelper/utils.go
@@ -17,6 +17,7 @@ package testhelper
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,7 +31,7 @@ import (
 	"github.com/sealerio/sealer/test/testhelper/settings"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	"github.com/sealerio/sealer/utils/exec"
-	"github.com/sealerio/sealer/utils/net"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	"github.com/sealerio/sealer/utils/os/fs"
 	"github.com/sealerio/sealer/utils/ssh"
 )
@@ -68,7 +69,7 @@ func WriteFile(fileName string, content []byte) error {
 }
 
 type SSHClient struct {
-	RemoteHostIP string
+	RemoteHostIP net.IP
 	SSH          ssh.Interface
 }
 
@@ -76,7 +77,7 @@ func NewSSHByCluster(cluster *v1.Cluster) ssh.Interface {
 	if cluster.Spec.SSH.User == "" {
 		cluster.Spec.SSH.User = common.ROOT
 	}
-	address, err := net.GetLocalHostAddresses()
+	address, err := utilsnet.GetLocalHostAddresses()
 	if err != nil {
 		logrus.Warnf("failed to get local address, %v", err)
 	}
@@ -95,12 +96,12 @@ func NewSSHByCluster(cluster *v1.Cluster) ssh.Interface {
 
 func NewSSHClientByCluster(cluster *v1.Cluster) *SSHClient {
 	var (
-		ipList []string
-		host   string
+		ipList []net.IP
+		host   net.IP
 	)
 	sshClient := NewSSHByCluster(cluster)
 	if cluster.Spec.Provider == common.AliCloud {
-		host = cluster.GetAnnotationsByKey(common.Eip)
+		host = net.ParseIP(cluster.GetAnnotationsByKey(common.Eip))
 		CheckNotEqual(host, "")
 		ipList = append(ipList, host)
 	} else {

--- a/types/api/v1/cluster_types.go
+++ b/types/api/v1/cluster_types.go
@@ -15,6 +15,8 @@
 package v1
 
 import (
+	"net"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +40,7 @@ type Hosts struct {
 	Count      string   `json:"count,omitempty"`
 	SystemDisk string   `json:"systemDisk,omitempty"`
 	DataDisks  []string `json:"dataDisks,omitempty"`
-	IPList     []string `json:"ipList,omitempty"`
+	IPList     []net.IP `json:"ipList,omitempty"`
 }
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/types/api/v1/zz_generated.deepcopy.go
+++ b/types/api/v1/zz_generated.deepcopy.go
@@ -20,6 +20,8 @@
 package v1
 
 import (
+	"net"
+
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -233,7 +235,7 @@ func (in *Hosts) DeepCopyInto(out *Hosts) {
 	}
 	if in.IPList != nil {
 		in, out := &in.IPList, &out.IPList
-		*out = make([]string, len(*in))
+		*out = make([]net.IP, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/types/api/v2/zz_generated.deepcopy.go
+++ b/types/api/v2/zz_generated.deepcopy.go
@@ -20,6 +20,8 @@
 package v2
 
 import (
+	"net"
+
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -134,7 +136,7 @@ func (in *Host) DeepCopyInto(out *Host) {
 	*out = *in
 	if in.IPS != nil {
 		in, out := &in.IPS, &out.IPS
-		*out = make([]string, len(*in))
+		*out = make([]net.IP, len(*in))
 		copy(*out, *in)
 	}
 	if in.Roles != nil {

--- a/utils/mount/mount_service.go
+++ b/utils/mount/mount_service.go
@@ -16,6 +16,7 @@ package mount
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/shirou/gopsutil/disk"
@@ -149,7 +150,7 @@ func GetMountDetails(target string) (bool, *Info) {
 	return mountCmdResultSplit(result, target)
 }
 
-func GetRemoteMountDetails(s ssh.Interface, ip string, target string) (bool, *Info) {
+func GetRemoteMountDetails(s ssh.Interface, ip net.IP, target string) (bool, *Info) {
 	result, err := s.Cmd(ip, fmt.Sprintf("mount | grep %s", target))
 	if err != nil {
 		return false, nil

--- a/utils/net/iputils_test.go
+++ b/utils/net/iputils_test.go
@@ -15,6 +15,7 @@
 package net
 
 import (
+	"net"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -79,4 +80,114 @@ func TestAssemblyIPList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIPStrsToIPs(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputIPStrs []string
+		wantedIPs   []net.IP
+	}{
+		{
+			name:        "baseData1",
+			inputIPStrs: []string{"10.110.101.1"},
+			wantedIPs:   []net.IP{net.ParseIP("10.110.101.1")},
+		},
+		{
+			name:        "baseData2",
+			inputIPStrs: []string{"10.110.101.1", "sdfghjkl"},
+			wantedIPs:   []net.IP{net.ParseIP("10.110.101.1"), nil},
+		},
+		{
+			name:        "baseData2",
+			inputIPStrs: []string{"10.110.101.1", "10.110.101.100"},
+			wantedIPs:   []net.IP{net.ParseIP("10.110.101.1"), net.ParseIP("10.110.101.100")},
+		},
+		{
+			name:        "empty input of nil",
+			inputIPStrs: nil,
+			wantedIPs:   nil,
+		},
+		{
+			name:        "non-empty input with empty string",
+			inputIPStrs: []string{""},
+			wantedIPs:   []net.IP{nil},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("start to test case %s", tt.name)
+			ips := IPStrsToIPs(tt.inputIPStrs)
+			if !equalNetIPs(ips, tt.wantedIPs) {
+				t.Errorf("wanted ips is (%s), but got (%s)", tt.wantedIPs, ips)
+			}
+		})
+	}
+}
+
+func TestIPsToIPStrs(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputIPs     []net.IP
+		wantedIPStrs []string
+	}{
+		{
+			name:         "baseData1",
+			inputIPs:     []net.IP{net.ParseIP("10.110.101.1")},
+			wantedIPStrs: []string{"10.110.101.1"},
+		},
+		{
+			name:         "baseData2",
+			inputIPs:     []net.IP{net.ParseIP("10.110.101.1"), net.ParseIP("10.110.101.2")},
+			wantedIPStrs: []string{"10.110.101.1", "10.110.101.2"},
+		},
+		{
+			name:         "baseData3",
+			inputIPs:     []net.IP{net.ParseIP("10.110.101.1"), net.ParseIP("10.110.101.653")},
+			wantedIPStrs: []string{"10.110.101.1", "<nil>"},
+		},
+		{
+			name:         "empty input of nil",
+			inputIPs:     nil,
+			wantedIPStrs: nil,
+		},
+		{
+			name:         "non-empty input with empty string",
+			inputIPs:     []net.IP{nil},
+			wantedIPStrs: []string{"<nil>"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("start to test case %s", tt.name)
+			ipStrs := IPsToIPStrs(tt.inputIPs)
+			if !equalIPStrs(ipStrs, tt.wantedIPStrs) {
+				t.Errorf("wanted IP strings is (%s), but got (%s)", tt.wantedIPStrs, ipStrs)
+			}
+		})
+	}
+}
+
+func equalNetIPs(a, b []net.IP) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if !a[index].Equal(b[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalIPStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+	return true
 }

--- a/utils/ssh/connect.go
+++ b/utils/ssh/connect.go
@@ -34,7 +34,7 @@ import (
 
 const DefaultSSHPort = "22"
 
-func (s *SSH) connect(host string) (*ssh.Client, error) {
+func (s *SSH) connect(host net.IP) (*ssh.Client, error) {
 	if s.Encrypted {
 		passwd, err := hash.AesDecrypt([]byte(s.Password))
 		if err != nil {
@@ -66,7 +66,7 @@ func (s *SSH) connect(host string) (*ssh.Client, error) {
 	return ssh.Dial("tcp", fmt.Sprintf("%s:%s", host, s.Port), clientConfig)
 }
 
-func (s *SSH) Connect(host string) (*ssh.Client, *ssh.Session, error) {
+func (s *SSH) Connect(host net.IP) (*ssh.Client, *ssh.Session, error) {
 	client, err := s.connect(host)
 	if err != nil {
 		return nil, nil, err
@@ -133,7 +133,7 @@ func (s *SSH) sshPasswordMethod(password string) ssh.AuthMethod {
 	return ssh.Password(password)
 }
 
-func (s *SSH) sftpConnect(host string) (*ssh.Client, *sftp.Client, error) {
+func (s *SSH) sftpConnect(host net.IP) (*ssh.Client, *sftp.Client, error) {
 	var (
 		sshClient  *ssh.Client
 		sftpClient *sftp.Client

--- a/utils/ssh/platform.go
+++ b/utils/ssh/platform.go
@@ -17,18 +17,19 @@ package ssh
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"strings"
 
 	v1 "github.com/sealerio/sealer/types/api/v1"
-	"github.com/sealerio/sealer/utils/net"
+	utilsnet "github.com/sealerio/sealer/utils/net"
 	"github.com/sealerio/sealer/utils/platform"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-func (s *SSH) Platform(host string) (v1.Platform, error) {
-	if net.IsLocalIP(host, s.LocalAddress) {
+func (s *SSH) Platform(host net.IP) (v1.Platform, error) {
+	if utilsnet.IsLocalIP(host, s.LocalAddress) {
 		return *platform.GetDefaultPlatform(), nil
 	}
 
@@ -67,7 +68,7 @@ func (s *SSH) Platform(host string) (v1.Platform, error) {
 	return platform.Normalize(remotePlatform), nil
 }
 
-func (s *SSH) getCPUInfo(host, pattern string) (info string, err error) {
+func (s *SSH) getCPUInfo(host net.IP, pattern string) (info string, err error) {
 	sshClient, sftpClient, err := s.sftpConnect(host)
 	if err != nil {
 		return "", fmt.Errorf("new sftp client failed %v", err)
@@ -103,7 +104,7 @@ func (s *SSH) getCPUInfo(host, pattern string) (info string, err error) {
 	return "", errors.Wrapf(platform.ErrNotFound, "getCPUInfo for pattern: %s", pattern)
 }
 
-func (s *SSH) getCPUVariant(os, arch, host string) (string, error) {
+func (s *SSH) getCPUVariant(os, arch string, host net.IP) (string, error) {
 	variant, err := s.getCPUInfo(host, "Cpu architecture")
 	if err != nil {
 		return "", err

--- a/utils/ssh/scp_test.go
+++ b/utils/ssh/scp_test.go
@@ -15,6 +15,7 @@
 package ssh
 
 import (
+	"net"
 	"testing"
 
 	"github.com/sealerio/sealer/utils/os/fs"
@@ -113,12 +114,12 @@ func TestSSHCopyLocalToRemote(t *testing.T) {
 
 func TestSSHFetchRemoteToLocal(t *testing.T) {
 	type args struct {
-		host       string
+		host       net.IP
 		localPath  string
 		remotePath string
 	}
 	var (
-		host = ""
+		host = net.IP{}
 		ssh  = SSH{
 			User:       "root",
 			Password:   "",

--- a/utils/ssh/ssh.go
+++ b/utils/ssh/ssh.go
@@ -33,23 +33,23 @@ type Interface interface {
 	// Copy local files to remote host
 	// scp -r /tmp root@192.168.0.2:/root/tmp => Copy("192.168.0.2","tmp","/root/tmp")
 	// need check md5sum
-	Copy(host, srcFilePath, dstFilePath string) error
+	Copy(host net.IP, srcFilePath, dstFilePath string) error
 	// Fetch copy remote host files to localhost
-	Fetch(host, srcFilePath, dstFilePath string) error
+	Fetch(host net.IP, srcFilePath, dstFilePath string) error
 	// CmdAsync exec command on remote host, and asynchronous return logs
-	CmdAsync(host string, cmd ...string) error
+	CmdAsync(host net.IP, cmd ...string) error
 	// Cmd exec command on remote host, and return combined standard output and standard error
-	Cmd(host, cmd string) ([]byte, error)
+	Cmd(host net.IP, cmd string) ([]byte, error)
 	// IsFileExist check remote file exist or not
-	IsFileExist(host, remoteFilePath string) (bool, error)
+	IsFileExist(host net.IP, remoteFilePath string) (bool, error)
 	// RemoteDirExist Remote file existence returns true, nil
-	RemoteDirExist(host, remoteDirpath string) (bool, error)
+	RemoteDirExist(host net.IP, remoteDirpath string) (bool, error)
 	// CmdToString exec command on remote host, and return spilt standard output and standard error
-	CmdToString(host, cmd, spilt string) (string, error)
+	CmdToString(host net.IP, cmd, spilt string) (string, error)
 	// Platform Get remote platform
-	Platform(host string) (v1.Platform, error)
+	Platform(host net.IP) (v1.Platform, error)
 
-	Ping(host string) error
+	Ping(host net.IP) error
 }
 
 type SSH struct {
@@ -87,10 +87,10 @@ func NewSSHClient(ssh *v1.SSH, isStdout bool) Interface {
 }
 
 // GetHostSSHClient is used to executed bash command and no std out to be printed.
-func GetHostSSHClient(hostIP string, cluster *v2.Cluster) (Interface, error) {
+func GetHostSSHClient(hostIP net.IP, cluster *v2.Cluster) (Interface, error) {
 	for _, host := range cluster.Spec.Hosts {
 		for _, ip := range host.IPS {
-			if hostIP == ip {
+			if hostIP.Equal(ip) {
 				if err := mergo.Merge(&host.SSH, &cluster.Spec.SSH); err != nil {
 					return nil, err
 				}
@@ -102,10 +102,10 @@ func GetHostSSHClient(hostIP string, cluster *v2.Cluster) (Interface, error) {
 }
 
 // NewStdoutSSHClient is used to show std out when execute bash command.
-func NewStdoutSSHClient(hostIP string, cluster *v2.Cluster) (Interface, error) {
+func NewStdoutSSHClient(hostIP net.IP, cluster *v2.Cluster) (Interface, error) {
 	for _, host := range cluster.Spec.Hosts {
 		for _, ip := range host.IPS {
-			if hostIP == ip {
+			if hostIP.Equal(ip) {
 				if err := mergo.Merge(&host.SSH, &cluster.Spec.SSH); err != nil {
 					return nil, err
 				}

--- a/utils/ssh/utils.go
+++ b/utils/ssh/utils.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"sync"
 	"time"
@@ -106,7 +107,7 @@ func GetClusterPlatform(cluster *v2.Cluster) (map[string]v1.Platform, error) {
 		if err != nil {
 			return nil, err
 		}
-		clusterStatus[IP], err = ssh.Platform(IP)
+		clusterStatus[IP.String()], err = ssh.Platform(IP)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +115,7 @@ func GetClusterPlatform(cluster *v2.Cluster) (map[string]v1.Platform, error) {
 	return clusterStatus, nil
 }
 
-func WaitSSHReady(ssh Interface, tryTimes int, hosts ...string) error {
+func WaitSSHReady(ssh Interface, tryTimes int, hosts ...net.IP) error {
 	var err error
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, h := range hosts {

--- a/utils/strings/strings.go
+++ b/utils/strings/strings.go
@@ -15,6 +15,7 @@
 package strings
 
 import (
+	"net"
 	"strings"
 	"unicode"
 )
@@ -181,20 +182,20 @@ func ConvertToMap(env []string) map[string]string {
 	return envs
 }
 
-func Diff(old, new []string) (add, sub []string) {
+func Diff(old, new []net.IP) (add, sub []net.IP) {
 	diffMap := make(map[string]bool)
 	for _, v := range old {
-		diffMap[v] = true
+		diffMap[v.String()] = true
 	}
 	for _, v := range new {
-		if !diffMap[v] {
+		if !diffMap[v.String()] {
 			add = append(add, v)
 		} else {
-			diffMap[v] = false
+			diffMap[v.String()] = false
 		}
 	}
 	for _, v := range old {
-		if diffMap[v] {
+		if diffMap[v.String()] {
 			sub = append(sub, v)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. This pull request modify all IP string in the sealer's main procedure with the type of net.IP.


In my opinion, IP string is only used for end users to input. While after the validation layer of sealer, they all should be the type of net.IP. Communicating with net.IP is quite convenient for inner functions. We don't have to transfer them at all. And when reading code, hackers could clearly catch the meaning of net.IP type instance very soon.

What is more, when we use net.IP to pass though all code, it would bring much convenience for us to support IPv6. And this is one part of work of @VinceCui 


### Does this pull request fix one issue?
none
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews

@kakaZhou719 This updated lots of code, please help to test this for the pull request with `/test apply`. 