### PR TITLE
log: make sealer log printing unified, structured and more readable

### DIFF
--- a/apply/applydriver/local.go
+++ b/apply/applydriver/local.go
@@ -139,13 +139,13 @@ func (c *Applier) reconcileCluster() error {
 	}
 	defer func() {
 		if err := c.unMountClusterImage(); err != nil {
-			logrus.Warnf("failed to umount image %s, %v", c.ClusterDesired.ClusterName, err)
+			logrus.Warnf("failed to umount image(%s): %v", c.ClusterDesired.ClusterName, err)
 		}
 	}()
 
 	baseImage, err := c.ImageStore.GetByName(c.ClusterDesired.Spec.Image, platform.GetDefaultPlatform())
 	if err != nil {
-		return fmt.Errorf("failed to get base image err: %s", err)
+		return fmt.Errorf("failed to get base image(%s): %v", baseImage.Name, err)
 	}
 	// if no rootfs ,try to install applications.
 	if baseImage.Spec.ImageConfig.ImageType == common.AppImage {
@@ -203,7 +203,7 @@ func (c *Applier) Upgrade(upgradeImgName string) error {
 	}
 	defer func() {
 		if err := c.unMountClusterImage(); err != nil {
-			logrus.Warnf("failed to umount image %s, %v", c.ClusterDesired.ClusterName, err)
+			logrus.Warnf("failed to umount image(%s): %v", c.ClusterDesired.ClusterName, err)
 		}
 	}()
 	return c.upgrade()
@@ -212,7 +212,7 @@ func (c *Applier) Upgrade(upgradeImgName string) error {
 func (c *Applier) upgrade() error {
 	runtimeInterface, err := runtime.NewDefaultRuntime(c.ClusterDesired, c.ClusterFile.GetKubeadmConfig())
 	if err != nil {
-		return fmt.Errorf("failed to init runtime, %v", err)
+		return fmt.Errorf("failed to init runtime: %v", err)
 	}
 	upgradeImgMeta, err := runtimeInterface.GetClusterMetadata()
 	if err != nil {

--- a/apply/applydriver/utils.go
+++ b/apply/applydriver/utils.go
@@ -71,7 +71,7 @@ func DeleteNodes(client *k8s.Client, nodeIPs []net.IP) error {
 			continue
 		}
 		if err := client.DeleteNode(node.Name); err != nil {
-			return fmt.Errorf("failed to delete node %v", err)
+			return fmt.Errorf("failed to delete node(%s): %v", node.Name, err)
 		}
 	}
 	return nil

--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -93,7 +93,7 @@ func (c *CreateProcessor) MountImage(cluster *v2.Cluster) error {
 	}
 	runTime, err := runtime.NewDefaultRuntime(cluster, c.ClusterFile.GetKubeadmConfig())
 	if err != nil {
-		return fmt.Errorf("failed to init runtime, %v", err)
+		return fmt.Errorf("failed to init runtime: %v", err)
 	}
 	c.Runtime = runTime
 	return nil

--- a/apply/processor/delete.go
+++ b/apply/processor/delete.go
@@ -37,7 +37,7 @@ type DeleteProcessor struct {
 func (d *DeleteProcessor) Reset(cluster *v2.Cluster) error {
 	runTime, err := runtime.NewDefaultRuntime(cluster, d.ClusterFile.GetKubeadmConfig())
 	if err != nil {
-		return fmt.Errorf("failed to init runtime, %v", err)
+		return fmt.Errorf("failed to init runtime: %v", err)
 	}
 
 	return runTime.Reset()

--- a/apply/processor/gen.go
+++ b/apply/processor/gen.go
@@ -107,12 +107,12 @@ func GenerateCluster(arg *ParserArg) (*v2.Cluster, error) {
 
 	c, err := k8s.Newk8sClient()
 	if err != nil {
-		return nil, fmt.Errorf("generate clusterfile failed, %s", err)
+		return nil, fmt.Errorf("failed to create k8s client: %s", err)
 	}
 
 	all, err := c.ListNodes()
 	if err != nil {
-		return nil, fmt.Errorf("generate clusterfile failed, %s", err)
+		return nil, fmt.Errorf("failed to list nodes: %s", err)
 	}
 	for _, n := range all.Items {
 		for _, v := range n.Status.Addresses {

--- a/apply/processor/scale.go
+++ b/apply/processor/scale.go
@@ -71,7 +71,7 @@ func (s *ScaleProcessor) GetPipeLine() ([]func(cluster *v2.Cluster) error, error
 func (s *ScaleProcessor) PreProcess(cluster *v2.Cluster) error {
 	runTime, err := runtime.NewDefaultRuntime(cluster, s.KubeadmConfig)
 	if err != nil {
-		return fmt.Errorf("failed to init runtime, %v", err)
+		return fmt.Errorf("failed to init default runtime: %v", err)
 	}
 	s.Runtime = runTime
 	s.Config = config.NewConfiguration(cluster)

--- a/build/build.go
+++ b/build/build.go
@@ -97,7 +97,7 @@ func (l liteBuilder) Build(name string, context string, kubefileName string) err
 		}
 	}
 
-	logrus.Infof("build image %s %s success", l.platform.Architecture, name)
+	logrus.Infof("succeed in building image(%s) with arch(%s)", name, l.platform.Architecture)
 	return nil
 }
 

--- a/build/buildimage/differ.go
+++ b/build/buildimage/differ.go
@@ -62,7 +62,7 @@ func (r registry) Process(srcPath, rootfs string) error {
 		eg.Go(func() error {
 			ima, err := parse(srcPath)
 			if err != nil {
-				return fmt.Errorf("failed to parse images from %s error is : %v", dispatchType, err)
+				return fmt.Errorf("failed to parse images from %s: %v", dispatchType, err)
 			}
 			images = append(images, ima...)
 			return nil

--- a/build/buildimage/executor.go
+++ b/build/buildimage/executor.go
@@ -233,7 +233,7 @@ func NewBuildImageByKubefile(kubefileName string, platform v1.Platform) (*v1.Ima
 		}
 		baseImage, err = imageStore.GetByName(layer0.Value, &platform)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get base image err: %s", err)
+			return nil, nil, fmt.Errorf("failed to get base image: %s", err)
 		}
 	}
 

--- a/build/buildimage/utils.go
+++ b/build/buildimage/utils.go
@@ -40,7 +40,7 @@ import (
 func initImageSpec(kubefile string) (*v1.Image, error) {
 	kubeFile, err := osi.NewFileReader(kubefile).ReadAll()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubefile: %v", err)
+		return nil, fmt.Errorf("failed to load Kubefile: %v", err)
 	}
 
 	rawImage, err := parser.NewParse().Parse(kubeFile)
@@ -50,7 +50,7 @@ func initImageSpec(kubefile string) (*v1.Image, error) {
 
 	layer0 := rawImage.Spec.Layers[0]
 	if layer0.Type != common.FROMCOMMAND {
-		return nil, fmt.Errorf("first line of kubefile must start with %s", common.FROMCOMMAND)
+		return nil, fmt.Errorf("first line of Kubefile must start with %s", common.FROMCOMMAND)
 	}
 
 	return rawImage, nil
@@ -135,7 +135,7 @@ func GetLayerMountInfo(baseLayers []v1.Layer) (mount.Service, error) {
 	for _, info := range mountInfos {
 		// if info.Lowers equal lowerLayers,means image already mounted.
 		if strings.Join(lowerLayers, ":") == strings.Join(info.Lowers, ":") {
-			logrus.Infof("get mount dir :%s success ", info.Target)
+			logrus.Infof("succeeded in getting mount dir(%s)", info.Target)
 			//nolint
 			return mount.NewMountService(info.Target, info.Upper, info.Lowers)
 		}

--- a/build/buildinstruction/copy.go
+++ b/build/buildinstruction/copy.go
@@ -58,7 +58,7 @@ func (c CopyInstruction) Exec(execContext ExecContext) (out Out, err error) {
 	if !isRemoteSource(src) {
 		cacheID, err = GenerateSourceFilesDigest(execContext.BuildContext, src)
 		if err != nil {
-			logrus.Warnf("failed to generate src digest,discard cache: %v", err)
+			logrus.Warnf("failed to generate src digest, discard cache: %v", err)
 		}
 
 		if execContext.ContinueCache {
@@ -74,12 +74,12 @@ func (c CopyInstruction) Exec(execContext ExecContext) (out Out, err error) {
 
 	tmp, err := fs.NewFilesystem().MkTmpdir()
 	if err != nil {
-		return out, fmt.Errorf("failed to create tmp dir %s:%v", tmp, err)
+		return out, fmt.Errorf("failed to create tmp dir(%s): %v", tmp, err)
 	}
 
 	err = c.collector.Collect(execContext.BuildContext, src, filepath.Join(tmp, c.dest))
 	if err != nil {
-		return out, fmt.Errorf("failed to collect files to temp dir %s, err: %v", tmp, err)
+		return out, fmt.Errorf("failed to collect files to temp dir(%s): %v", tmp, err)
 	}
 	// if we come here, its new layer need set cache id .
 	layerID, err = execContext.LayerStore.RegisterLayerForBuilder(tmp)

--- a/build/layerutils/charts/charts.go
+++ b/build/layerutils/charts/charts.go
@@ -27,7 +27,7 @@ func (charts *Charts) ListImages(chartPath string) ([]string, error) {
 	var list []string
 	images, err := GetImageList(chartPath)
 	if err != nil {
-		return list, fmt.Errorf("get images failed,chart path:%s, err: %s", chartPath, err)
+		return list, fmt.Errorf("failed to get images chart path(%s), err: %s", chartPath, err)
 	}
 	if len(images) != 0 {
 		list = append(list, images...)

--- a/build/layerutils/charts/helm.go
+++ b/build/layerutils/charts/helm.go
@@ -56,14 +56,14 @@ func RenderHelmChart(chartPath string) (map[string]string, error) {
 	}
 	valuesToRender, err := chartutil.ToRenderValues(ch, nil, options, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to render values %v", err)
+		return nil, fmt.Errorf("failed to render values: %v", err)
 	}
 
 	content, err := engine.Render(ch, valuesToRender)
 	if err != nil {
 		b, _ := json.Marshal(valuesToRender)
 		logrus.Debugf("values is %s", b)
-		return nil, fmt.Errorf("render helm chart error %s", err.Error())
+		return nil, fmt.Errorf("failed to render helm chart: %s", err)
 	}
 
 	return content, nil
@@ -73,7 +73,7 @@ func GetImageList(chartPath string) ([]string, error) {
 	var list []string
 	content, err := RenderHelmChart(chartPath)
 	if err != nil {
-		return list, fmt.Errorf("render helm chart failed %s", err)
+		return list, fmt.Errorf("failed to render helm chart: %s", err)
 	}
 
 	for _, v := range content {

--- a/build/layerutils/manifests/manifests.go
+++ b/build/layerutils/manifests/manifests.go
@@ -30,7 +30,7 @@ func (manifests *Manifests) ListImages(yamlFile string) ([]string, error) {
 
 	yamlBytes, err := ioutil.ReadFile(filepath.Clean(yamlFile))
 	if err != nil {
-		return nil, fmt.Errorf("read file failed %s", err)
+		return nil, fmt.Errorf("failed to read file: %s", err)
 	}
 
 	images := layerutils.DecodeImages(string(yamlBytes))
@@ -39,7 +39,7 @@ func (manifests *Manifests) ListImages(yamlFile string) ([]string, error) {
 	}
 
 	if err != nil {
-		return list, fmt.Errorf("filepath walk failed %s", err)
+		return list, fmt.Errorf("failed to walk filepath: %s", err)
 	}
 
 	return list, nil

--- a/cmd/sealer/cmd/cert.go
+++ b/cmd/sealer/cmd/cert.go
@@ -46,7 +46,7 @@ var certCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cluster, err := clusterfile.GetDefaultCluster()
 		if err != nil {
-			return fmt.Errorf("get default cluster failed, %v", err)
+			return fmt.Errorf("failed to get default cluster: %v", err)
 		}
 		clusterFile, err := clusterfile.NewClusterFile(cluster.GetAnnotationsByKey(common.ClusterfileName))
 		if err != nil {
@@ -54,7 +54,7 @@ var certCmd = &cobra.Command{
 		}
 		r, err := runtime.NewDefaultRuntime(cluster, clusterFile.GetKubeadmConfig())
 		if err != nil {
-			return fmt.Errorf("get default runtime failed, %v", err)
+			return fmt.Errorf("failed to get default runtime: %v", err)
 		}
 		return r.UpdateCert(strings.Split(altNames, ","))
 	},

--- a/cmd/sealer/cmd/gen.go
+++ b/cmd/sealer/cmd/gen.go
@@ -53,7 +53,7 @@ Then you can use any sealer command to manage the cluster like:
 	sealer run mysql-cluster:5.8`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if flag.Passwd == "" || flag.Image == "" {
-			return fmt.Errorf("empty password or image name")
+			return fmt.Errorf("password and image name cannot be empty")
 		}
 		cluster, err := processor.GenerateCluster(flag)
 		if err != nil {

--- a/cmd/sealer/cmd/pull.go
+++ b/cmd/sealer/cmd/pull.go
@@ -45,7 +45,7 @@ var pullCmd = &cobra.Command{
 		if err := imgSvc.Pull(args[0], plat); err != nil {
 			return err
 		}
-		logrus.Infof("Pull %s success", args[0])
+		logrus.Infof("succeed in pulling ClusterImage(%s)", args[0])
 		return nil
 	},
 }

--- a/cmd/sealer/cmd/search.go
+++ b/cmd/sealer/cmd/search.go
@@ -54,7 +54,7 @@ ex.:
 			}
 			rNamed, err := reference2.WithName(named.Repo())
 			if err != nil {
-				return fmt.Errorf("get repository name error: %v", err)
+				return fmt.Errorf("failed to get repository name: %v", err)
 			}
 			repo, err := ns.Repository(context.Background(), rNamed)
 			if err != nil {

--- a/pkg/checker/host_checker.go
+++ b/pkg/checker/host_checker.go
@@ -49,14 +49,14 @@ func checkHostnameUnique(cluster *v2.Cluster, ipList []net.IP) error {
 	for _, ip := range ipList {
 		s, err := ssh.GetHostSSHClient(ip, cluster)
 		if err != nil {
-			return fmt.Errorf("checker: failed to get host %s client,%v", ip, err)
+			return fmt.Errorf("checker: failed to get ssh client of host(%s): %v", ip, err)
 		}
 		hostname, err := s.CmdToString(ip, "hostname", "")
 		if err != nil {
-			return fmt.Errorf("checker: failed to get host %s hostname, %v", ip, err)
+			return fmt.Errorf("checker: failed to get hostname of host(%s): %v", ip, err)
 		}
 		if hostnameList[hostname] {
-			return fmt.Errorf("checker: hostname cannot be repeated, please set diffent hostname")
+			return fmt.Errorf("checker: hostname of host(%s) cannot be repeated, please set diffent hostname", ip)
 		}
 		hostnameList[hostname] = true
 	}
@@ -68,19 +68,19 @@ func checkTimeSync(cluster *v2.Cluster, ipList []net.IP) error {
 	for _, ip := range ipList {
 		s, err := ssh.GetHostSSHClient(ip, cluster)
 		if err != nil {
-			return fmt.Errorf("checker: failed to get host %s client,%v", ip, err)
+			return fmt.Errorf("checker: failed to get ssh client of host(%s): %v", ip, err)
 		}
 		timeStamp, err := s.CmdToString(ip, "date +%s", "")
 		if err != nil {
-			return fmt.Errorf("checker: failed to get %s timestamp, %v", ip, err)
+			return fmt.Errorf("checker: failed to get timestamp of host(%s): %v", ip, err)
 		}
 		ts, err := strconv.Atoi(timeStamp)
 		if err != nil {
-			return fmt.Errorf("checker: failed to reverse timestamp %s, %v", timeStamp, err)
+			return fmt.Errorf("checker: failed to reverse timestamp %s of host(%s): %v", timeStamp, ip, err)
 		}
 		timeDiff := time.Since(time.Unix(int64(ts), 0)).Minutes()
 		if timeDiff < -1 || timeDiff > 1 {
-			return fmt.Errorf("checker: the time of %s node is not synchronized", ip)
+			return fmt.Errorf("checker: time of host(%s) is not synchronized", ip)
 		}
 	}
 	return nil

--- a/pkg/checker/registry_checker.go
+++ b/pkg/checker/registry_checker.go
@@ -54,7 +54,7 @@ func (r *RegistryChecker) Check(cluster *v2.Cluster, phase string) error {
 
 	err = distributionutil.Login(context.Background(), &authConfig)
 	if err != nil {
-		return fmt.Errorf("%v authentication failed", r.RegistryDomain)
+		return fmt.Errorf("failed to login %v: %v", r.RegistryDomain, err)
 	}
 	return nil
 }

--- a/pkg/checker/svc_checker.go
+++ b/pkg/checker/svc_checker.go
@@ -15,6 +15,7 @@
 package checker
 
 import (
+	"fmt"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -105,8 +106,8 @@ func (n *SvcChecker) Output(svcNamespaceStatusList []*SvcNamespaceStatus) error 
 	t = template.Must(t, err)
 	err = t.Execute(common.StdOut, svcNamespaceStatusList)
 	if err != nil {
-		logrus.Errorf("service checkers template can not excute %s", err)
-		return err
+		logrus.Errorf("service checkers template can not be executed: %s", err)
+		return fmt.Errorf("service checkers template can not be executed: %s", err)
 	}
 	return nil
 }

--- a/pkg/client/docker/images.go
+++ b/pkg/client/docker/images.go
@@ -39,7 +39,7 @@ func (d Docker) ImagesPull(images []string) error {
 			continue
 		}
 		if err := d.ImagePull(trimQuotes(strings.TrimSpace(image))); err != nil {
-			return fmt.Errorf("image %s pull failed: %v", image, err)
+			return fmt.Errorf("failed to pull image(%s): %v", image, err)
 		}
 	}
 	return nil
@@ -57,7 +57,7 @@ func trimQuotes(s string) string {
 func (d Docker) ImagesPullByImageListFile(fileName string) error {
 	data, err := os.NewFileReader(fileName).ReadLines()
 	if err != nil {
-		logrus.Error(fmt.Sprintf("Read image list failed: %v", err))
+		logrus.Error(fmt.Sprintf("failed to read image list: %v", err))
 	}
 	return d.ImagesPull(data)
 }
@@ -91,7 +91,7 @@ func (d Docker) ImagePull(image string) error {
 	if err != nil && err != io.ErrClosedPipe {
 		logrus.Warnf("error occurs in display progressing, err: %v", err)
 	}
-	logrus.Infof("success to pull docker image: %s ", image)
+	logrus.Infof("succeed in pulling docker image(%s) ", image)
 	return nil
 }
 

--- a/pkg/client/docker/utils.go
+++ b/pkg/client/docker/utils.go
@@ -47,7 +47,7 @@ func GetCanonicalImagePullOptions(canonicalImageName string) types.ImagePullOpti
 
 	named, err := normalreference.ParseToNamed(canonicalImageName)
 	if err != nil {
-		logrus.Warnf("parse canonical ImageName failed: %v", err)
+		logrus.Warnf("failed to parse canonical ImageName: %v", err)
 		return opts
 	}
 
@@ -65,7 +65,7 @@ func GetCanonicalImagePullOptions(canonicalImageName string) types.ImagePullOpti
 	if err == nil {
 		encodedJSON, err = json.Marshal(authConfig)
 		if err != nil {
-			logrus.Warnf("authConfig encodedJSON failed: %v", err)
+			logrus.Warnf("failed to authConfig encodedJSON: %v", err)
 		} else {
 			authStr = base64.URLEncoding.EncodeToString(encodedJSON)
 		}

--- a/pkg/client/k8s/client.go
+++ b/pkg/client/k8s/client.go
@@ -89,7 +89,7 @@ func (c *Client) UpdateNode(node v1.Node) (*v1.Node, error) {
 
 func (c *Client) DeleteNode(name string) error {
 	if err := c.client.CoreV1().Nodes().Delete(context.TODO(), name, metav1.DeleteOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to delete cluster node %s", name)
+		return errors.Wrapf(err, "failed to delete cluster node(%s)", name)
 	}
 	return nil
 }

--- a/pkg/clusterfile/pre_process.go
+++ b/pkg/clusterfile/pre_process.go
@@ -102,7 +102,7 @@ func (c *ClusterFile) PrePareCluster() error {
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Warnf("failed to close file")
 		}
 	}()
 	d := yaml.NewYAMLOrJSONDecoder(f, 4096)

--- a/pkg/clusterfile/util.go
+++ b/pkg/clusterfile/util.go
@@ -46,7 +46,7 @@ func GetDefaultClusterName() (string, error) {
 	if len(clusters) == 1 {
 		return clusters[0], nil
 	} else if len(clusters) > 1 {
-		return "", fmt.Errorf("Select a cluster through the -c parameter: " + strings.Join(clusters, ","))
+		return "", fmt.Errorf("select a cluster through the -c parameter: " + strings.Join(clusters, ","))
 	}
 
 	return "", ErrClusterNotExist
@@ -55,7 +55,7 @@ func GetDefaultClusterName() (string, error) {
 func GetClusterFromFile(filepath string) (cluster *v2.Cluster, err error) {
 	cluster = &v2.Cluster{}
 	if err = yamlUtils.UnmarshalFile(filepath, cluster); err != nil {
-		return nil, fmt.Errorf("failed to get cluster from %s, %v", filepath, err)
+		return nil, fmt.Errorf("failed to get cluster from %s: %v", filepath, err)
 	}
 	cluster.SetAnnotations(common.ClusterfileName, filepath)
 	return cluster, nil
@@ -78,7 +78,7 @@ func SaveToDisk(cluster *v2.Cluster, clusterName string) error {
 	fileName := common.GetClusterWorkClusterfile(clusterName)
 	err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("mkdir failed %s %v", fileName, err)
+		return fmt.Errorf("failed to mkdir %s: %v", fileName, err)
 	}
 
 	// if user run cluster image without password,skip to encrypt.

--- a/pkg/config/pre_process.go
+++ b/pkg/config/pre_process.go
@@ -82,7 +82,7 @@ func (t toJSONProcessor) Process(config *v1.Config) error {
 	if v, ok := config.Labels[trueLabelKey]; !ok || v != trueLabelValue {
 		json, err := yaml.YAMLToJSON([]byte(config.Spec.Data))
 		if err != nil {
-			return fmt.Errorf("failed to resolve config data to json, %v", err)
+			return fmt.Errorf("failed to resolve config data to json: %v", err)
 		}
 		config.Spec.Data = string(json)
 		return nil
@@ -91,25 +91,25 @@ func (t toJSONProcessor) Process(config *v1.Config) error {
 	dataMap := make(map[string]interface{})
 	err := yaml.Unmarshal([]byte(config.Spec.Data), &dataMap)
 	if err != nil {
-		return fmt.Errorf("convert yaml data to map failed, %v", err)
+		return fmt.Errorf("failed to convert yaml data to map: %v", err)
 	}
 
 	for k, v := range dataMap {
 		data, err := yaml.Marshal(v)
 		if err != nil {
-			return fmt.Errorf("encode yaml failed,%v", err)
+			return fmt.Errorf("failed to encode yaml: %v", err)
 		}
 
 		bytes, err := yaml.YAMLToJSON(data)
 		if err != nil {
-			return fmt.Errorf("toJson: failed to convert yaml to json, key is %s, %v", k, err)
+			return fmt.Errorf("toJson: failed to convert yaml to json, key is %s: %v", k, err)
 		}
 		dataMap[k] = string(bytes)
 	}
 
 	data, err := yaml2.Marshal(dataMap)
 	if err != nil {
-		return fmt.Errorf("failed to convert data map, %v,%v", dataMap, err)
+		return fmt.Errorf("failed to convert data map(%v): %v", dataMap, err)
 	}
 	config.Spec.Data = string(data)
 
@@ -127,7 +127,7 @@ func (t toBase64Processor) Process(config *v1.Config) error {
 	dataMap := make(map[string]string)
 	err := yaml.Unmarshal([]byte(config.Spec.Data), &dataMap)
 	if err != nil {
-		return fmt.Errorf("tobase64: convert yaml data to map failed, %v", err)
+		return fmt.Errorf("tobase64: failed to convert yaml data to map: %v", err)
 	}
 
 	for k, v := range dataMap {
@@ -135,7 +135,7 @@ func (t toBase64Processor) Process(config *v1.Config) error {
 	}
 	bs, err := yaml.Marshal(dataMap)
 	if err != nil {
-		return fmt.Errorf("failed to convert base64 to yaml, %v", err)
+		return fmt.Errorf("failed to convert base64 to yaml: %v", err)
 	}
 
 	config.Spec.Data = string(bs)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -84,10 +84,10 @@ func (p *processor) RenderAll(host net.IP, dir string) error {
 			"b64dec": base64decode,
 		}).ParseFiles(path)
 		if err != nil {
-			return fmt.Errorf("failed to create template: %s %v", path, err)
+			return fmt.Errorf("failed to create template(%s): %v", path, err)
 		}
 		if err := t.Execute(writer, p.getHostEnv(host)); err != nil {
-			return fmt.Errorf("failed to render env template: %s %v", path, err)
+			return fmt.Errorf("failed to render env template(%s): %v", path, err)
 		}
 		return nil
 	})

--- a/pkg/filesystem/cloudfilesystem/overlay2.go
+++ b/pkg/filesystem/cloudfilesystem/overlay2.go
@@ -42,7 +42,7 @@ func (o *overlayFileSystem) MountRootfs(cluster *v2.Cluster, hosts []net.IP, ini
 	clusterRootfsDir := common.DefaultTheClusterRootfsDir(cluster.Name)
 	//scp roofs to all Masters and Nodes,then do init.sh
 	if err := mountRootfs(hosts, clusterRootfsDir, cluster, initFlag); err != nil {
-		return fmt.Errorf("mount rootfs failed %v", err)
+		return fmt.Errorf("failed to mount rootfs(%s): %v", clusterRootfsDir, err)
 	}
 	return nil
 }
@@ -78,16 +78,16 @@ func mountRootfs(ipList []net.IP, target string, cluster *v2.Cluster, initFlag b
 			mountEntry.Unlock()
 			sshClient, err := ssh.GetHostSSHClient(ip, cluster)
 			if err != nil {
-				return fmt.Errorf("get host ssh client failed %v", err)
+				return fmt.Errorf("failed to get ssh client of host(%s): %v", ip, err)
 			}
 			err = copyFiles(sshClient, ip, src, target)
 			if err != nil {
-				return fmt.Errorf("copy rootfs failed %v", err)
+				return fmt.Errorf("failed to copy rootfs: %v", err)
 			}
 			if initFlag {
 				err = sshClient.CmdAsync(ip, env.NewEnvProcessor(cluster).WrapperShell(ip, initCmd))
 				if err != nil {
-					return fmt.Errorf("exec init.sh failed %v", err)
+					return fmt.Errorf("failed to exec init.sh: %v", err)
 				}
 			}
 			return err

--- a/pkg/filesystem/cloudfilesystem/utils.go
+++ b/pkg/filesystem/cloudfilesystem/utils.go
@@ -32,7 +32,7 @@ import (
 func copyFiles(sshEntry ssh.Interface, ip net.IP, src, target string) error {
 	files, err := ioutil.ReadDir(src)
 	if err != nil {
-		return fmt.Errorf("failed to copy files %s", err)
+		return fmt.Errorf("failed to copy files: %s", err)
 	}
 
 	for _, f := range files {
@@ -41,7 +41,7 @@ func copyFiles(sshEntry ssh.Interface, ip net.IP, src, target string) error {
 		}
 		err = sshEntry.Copy(ip, filepath.Join(src, f.Name()), filepath.Join(target, f.Name()))
 		if err != nil {
-			return fmt.Errorf("failed to copy sub files %v", err)
+			return fmt.Errorf("failed to copy sub files: %v", err)
 		}
 	}
 	return nil

--- a/pkg/filesystem/clusterimage/clusterimage.go
+++ b/pkg/filesystem/clusterimage/clusterimage.go
@@ -72,7 +72,7 @@ func (m *mounter) umountImage(cluster *v2.Cluster) error {
 				return mount.NewMountDriver().Unmount(filepath.Join(mountRootDir, f.Name()))
 			})
 			if err != nil {
-				return fmt.Errorf("failed to unmount dir %s,err: %v", filepath.Join(mountRootDir, f.Name()), err)
+				return fmt.Errorf("failed to unmount dir(%s): %v", filepath.Join(mountRootDir, f.Name()), err)
 			}
 		}
 	}
@@ -107,7 +107,7 @@ func (m *mounter) mountImage(cluster *v2.Cluster) error {
 		}
 		if osi.IsFileExist(mountDir) {
 			if err = m.fs.RemoveAll(mountDir); err != nil {
-				return fmt.Errorf("failed to clean %s, %v", mountDir, err)
+				return fmt.Errorf("failed to clean %s: %v", mountDir, err)
 			}
 		}
 		Image, err := m.imageStore.GetByName(cluster.Spec.Image, &pfm)
@@ -116,14 +116,14 @@ func (m *mounter) mountImage(cluster *v2.Cluster) error {
 		}
 		layers, err := image.GetImageLayerDirs(Image)
 		if err != nil {
-			return fmt.Errorf("get layers failed: %v", err)
+			return fmt.Errorf("failed to get layers: %v", err)
 		}
 
 		if err = m.fs.MkdirAll(upperDir); err != nil {
-			return fmt.Errorf("create upperdir failed, %s", err)
+			return fmt.Errorf("failed to create upperdir: %s", err)
 		}
 		if err = driver.Mount(mountDir, upperDir, layers...); err != nil {
-			return fmt.Errorf("mount files failed %v", err)
+			return fmt.Errorf("failed to mount files: %v", err)
 		}
 		// use env list to render image mount dir: etc,charts,manifests.
 		err = renderENV(mountDir, cluster.GetAllIPList(), env.NewEnvProcessor(cluster))

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -36,7 +36,7 @@ func NewClusterImageMounter() (clusterimage.Interface, error) {
 func NewFilesystem(rootfs string) (cloudfilesystem.Interface, error) {
 	md, err := runtime.LoadMetadata(rootfs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load Metadata file to determine the filesystem type %v", err)
+		return nil, fmt.Errorf("failed to load Metadata file to determine the filesystem type: %v", err)
 	}
 
 	if md == nil || !md.NydusFlag {

--- a/pkg/guest/guest.go
+++ b/pkg/guest/guest.go
@@ -56,7 +56,7 @@ func (d *Default) Apply(cluster *v2.Cluster) error {
 
 	image, err := d.imageStore.GetByName(cluster.Spec.Image, platform.GetDefaultPlatform())
 	if err != nil {
-		return fmt.Errorf("get ClusterImage failed, %s", err)
+		return fmt.Errorf("failed to get ClusterImage: %s", err)
 	}
 	cmdArgs := d.getGuestCmdArg(cluster, image)
 	cmd := d.getGuestCmd(cluster, image)

--- a/pkg/image/cache/chain.go
+++ b/pkg/image/cache/chain.go
@@ -160,7 +160,7 @@ func (cs *chainStore) Images() map[ImageID]*v1.Image {
 		img := &v1.Image{}
 		err = yaml.Unmarshal(config, img)
 		if err != nil {
-			logrus.Error("failed to unmarshal bytes into image")
+			logrus.Errorf("failed to unmarshal bytes into image: %v", err)
 			continue
 		}
 		dgst := digest.FromBytes(config)

--- a/pkg/image/default_image.go
+++ b/pkg/image/default_image.go
@@ -109,11 +109,11 @@ func (d DefaultImageService) Pull(imageName string, platforms []*v1.Platform) er
 
 	manifest, err := repo.Manifests(ctx, make([]distribution.ManifestServiceOption, 0)...)
 	if err != nil {
-		return fmt.Errorf("get manifest service error: %v", err)
+		return fmt.Errorf("failed to get manifest service: %v", err)
 	}
 	desc, err := repo.Tags(ctx).Get(ctx, named.Tag())
 	if err != nil {
-		return fmt.Errorf("get %s tag descriptor error: %v, try \"docker login\" if you are using a private registry", named.Repo(), err)
+		return fmt.Errorf("failed to get %s tag descriptor: %v. \nTry \"docker login\" if you are using a private registry", named.Repo(), err)
 	}
 
 	puller, err := distributionutil.NewPuller(repo, distributionutil.Config{
@@ -134,7 +134,7 @@ func (d DefaultImageService) Pull(imageName string, platforms []*v1.Platform) er
 	dockerprogress.Message(progressChanOut, "", fmt.Sprintf("Start to Pull Image %s", named.Raw()))
 	maniList, err := manifest.Get(ctx, desc.Digest, make([]distribution.ManifestServiceOption, 0)...)
 	if err != nil {
-		return fmt.Errorf("get image manifest error: %v", err)
+		return fmt.Errorf("failed to get image manifest: %v", err)
 	}
 	_, p, err := maniList.Payload()
 	if err != nil {
@@ -143,7 +143,7 @@ func (d DefaultImageService) Pull(imageName string, platforms []*v1.Platform) er
 	for _, plat := range platforms {
 		m, err := d.handleManifest(ctx, manifest, p, *plat)
 		if err != nil {
-			return fmt.Errorf("get digest error: %v", err)
+			return fmt.Errorf("failed to get digest: %v", err)
 		}
 
 		image, err := puller.Pull(ctx, named, m)
@@ -163,12 +163,12 @@ func (d DefaultImageService) Pull(imageName string, platforms []*v1.Platform) er
 func (d DefaultImageService) handleManifest(ctx context.Context, manifest distribution.ManifestService, payload []byte, platform v1.Platform) (schema2.Manifest, error) {
 	dgest, err := distributionutil.GetImageManifestDigest(payload, platform)
 	if err != nil {
-		return schema2.Manifest{}, fmt.Errorf("get digest from manifest list error: %v", err)
+		return schema2.Manifest{}, fmt.Errorf("failed to get digest from manifest list: %v", err)
 	}
 
 	m, err := manifest.Get(ctx, dgest, make([]distribution.ManifestServiceOption, 0)...)
 	if err != nil {
-		return schema2.Manifest{}, fmt.Errorf("get image manifest error: %v", err)
+		return schema2.Manifest{}, fmt.Errorf("failed to get image manifest: %v", err)
 	}
 
 	_, ok := m.(*schema2.DeserializedManifest)
@@ -298,11 +298,11 @@ func (d DefaultImageService) Delete(imageNameOrID string, platforms []*v1.Platfo
 			for _, plat := range platforms {
 				img, err := imageStore.GetByName(imageNameOrID, plat)
 				if err != nil {
-					return fmt.Errorf("image %s not found %v", imageNameOrID, err)
+					return fmt.Errorf("failed to get image(%s): %v", imageNameOrID, err)
 				}
 
 				if err = imageStore.DeleteByName(imageNameOrID, plat); err != nil {
-					return fmt.Errorf("failed to delete image %s, err: %v", imageNameOrID, err)
+					return fmt.Errorf("failed to delete image(%s): %v", imageNameOrID, err)
 				}
 				deleteImageIDList = append(deleteImageIDList, img.Spec.ID)
 			}

--- a/pkg/image/default_image_file.go
+++ b/pkg/image/default_image_file.go
@@ -56,7 +56,7 @@ func (d DefaultImageFileService) Load(imageSrc string) error {
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil {
-			logrus.Error("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 
@@ -79,7 +79,7 @@ func (d DefaultImageFileService) Load(imageSrc string) error {
 	}
 	defer func() {
 		if err := os.Remove(repoFile); err != nil {
-			logrus.Error("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 

--- a/pkg/image/distributionutil/pull.go
+++ b/pkg/image/distributionutil/pull.go
@@ -137,7 +137,7 @@ func (puller *ImagePuller) downloadLayer(ctx context.Context, layer store.Layer,
 	// update rolayer size for storing the info under layerdb
 	layer.SetSize(size)
 	if digester.Digest() != descriptor.Digest {
-		return fmt.Errorf("digest verified failed for %s", layer.ID())
+		return fmt.Errorf("failed to verify digest for %s", layer.ID())
 	}
 	progress.Update(progressOut, layer.SimpleID(), "pull completed")
 	return nil

--- a/pkg/image/distributionutil/push.go
+++ b/pkg/image/distributionutil/push.go
@@ -54,7 +54,7 @@ func (pusher *ImagePusher) Push(ctx context.Context, named reference.Named) erro
 
 	manifestList, ok := imageMetadata[named.CompleteName()]
 	if !ok {
-		return fmt.Errorf("image: %s not found", named.Raw())
+		return fmt.Errorf("image(%s) not found", named.Raw())
 	}
 
 	for _, m := range manifestList.Manifests {
@@ -114,7 +114,7 @@ func (pusher *ImagePusher) push(ctx context.Context, image v1.Image, named refer
 		}
 		err := l.ID.Validate()
 		if err != nil {
-			return nil, fmt.Errorf("layer hash %s validate failed, err: %s", l.ID, err)
+			return nil, fmt.Errorf("failed to validate layer hash %s: %s", l.ID, err)
 		}
 
 		// this scope value, safe to pass into eg.Go
@@ -296,7 +296,7 @@ func (pusher *ImagePusher) putManifestConfig(ctx context.Context, image v1.Image
 
 	dockerImageConfig, err := addDockerManifestConfig(image)
 	if err != nil {
-		return nil, fmt.Errorf("add docker manifest config error: %s", err)
+		return nil, fmt.Errorf("failed to add docker manifest config: %s", err)
 	}
 
 	configJSON, err := json.Marshal(dockerImageConfig)

--- a/pkg/image/distributionutil/registry.go
+++ b/pkg/image/distributionutil/registry.go
@@ -39,7 +39,7 @@ func NewV2Repository(named reference.Named, actions ...string) (distribution.Rep
 
 	authConfig, err := svc.GetAuthByDomain(domain)
 	if err != nil && authConfig != defaultAuth {
-		return nil, fmt.Errorf("failed to get auth info for domain%s: %v", domain, err)
+		return nil, fmt.Errorf("failed to get auth info for domain(%s): %v", domain, err)
 	}
 
 	return getV2Repository(authConfig, named, actions...)

--- a/pkg/image/distributionutil/utils.go
+++ b/pkg/image/distributionutil/utils.go
@@ -47,7 +47,7 @@ func buildManifestDescriptor(descriptor distribution.Descriptor, imageManifest *
 	}
 
 	if err := manifest.Descriptor.Digest.Validate(); err != nil {
-		return manifestlist.ManifestDescriptor{}, errors.Wrap(err, "digest parse of image failed")
+		return manifestlist.ManifestDescriptor{}, errors.Wrap(err, "failed to parse digest of image")
 	}
 	return manifest, nil
 }

--- a/pkg/image/store/filesystem.go
+++ b/pkg/image/store/filesystem.go
@@ -146,7 +146,7 @@ func (fs *filesystem) Set(data []byte) (digest.Digest, error) {
 
 	dgst = digest.FromBytes(data)
 	if err = ioutil.WriteFile(metadataDir(dgst), data, common.FileMode0644); err != nil {
-		return "", errors.Errorf("failed to write image %s's metadata, err: %v", dgst, err)
+		return "", errors.Errorf("failed to write metadata of image(%s): %v", dgst, err)
 	}
 
 	return dgst, nil
@@ -424,7 +424,7 @@ func (fs *filesystem) getImageByID(id string) (*v1.Image, error) {
 
 	err := yamlUtils.UnmarshalFile(filename, &image)
 	if err != nil {
-		return nil, fmt.Errorf("no such image id:%s", id)
+		return nil, fmt.Errorf("no such image id(%s)", id)
 	}
 
 	return &image, nil
@@ -504,7 +504,7 @@ func (fs *filesystem) getImageMetadataItem(name string, platform *v1.Platform) (
 
 	manifestList, ok := imageMetadataMap[name]
 	if !ok {
-		return nil, fmt.Errorf("image %s not found", name)
+		return nil, fmt.Errorf("image(%s) not found", name)
 	}
 
 	for _, m := range manifestList.Manifests {
@@ -569,7 +569,7 @@ func (fs *filesystem) saveImage(image v1.Image) error {
 
 	size, err := fs.fi.GetFilesSize(res)
 	if err != nil {
-		return fmt.Errorf("failed to get image %s size, %v", image.Name, err)
+		return fmt.Errorf("failed to get image size of image(%s): %v", image.Name, err)
 	}
 	return fs.setImageMetadata(image.Name, &types.ManifestDescriptor{ID: image.Spec.ID, SIZE: size, Platform: image.Spec.Platform})
 }

--- a/pkg/image/types/error.go
+++ b/pkg/image/types/error.go
@@ -21,5 +21,5 @@ type ImageNameOrIDNotFoundError struct {
 }
 
 func (e *ImageNameOrIDNotFoundError) Error() string {
-	return fmt.Sprintf("failed to find imageName or imageId %s", e.Name)
+	return fmt.Sprintf("failed to find imageName or imageId(%s)", e.Name)
 }

--- a/pkg/image/util.go
+++ b/pkg/image/util.go
@@ -45,7 +45,7 @@ func GetImageDetails(idOrName string, platforms []*v1.Platform) (string, error) 
 	var imgs []*v1.Image
 
 	if idOrName == "" {
-		return "", fmt.Errorf("image id is nil")
+		return "", fmt.Errorf("image id or name cannot be empty")
 	}
 	imageStore, err := store.NewDefaultImageStore()
 	if err != nil {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -106,7 +106,7 @@ func (p *Parser) Parse(kubeFile []byte) (*v1.Image, error) {
 
 		layerType, layerValue, err := decodeLine(line)
 		if err != nil {
-			return nil, fmt.Errorf("decode kubeFile line failed, line: %d ,err: %v", currentLine, err)
+			return nil, fmt.Errorf("failed to decode line %d of Kubefile: %v", currentLine, err)
 		}
 
 		switch layerType {
@@ -128,7 +128,7 @@ func decodeLine(line string) (string, string, error) {
 	}
 	cmd := strings.ToUpper(cmdline[0])
 	if !validCommands[cmd] {
-		return "", "", fmt.Errorf("invalid command %s %s", cmdline[0], line)
+		return "", "", fmt.Errorf("invalid command type(%s) in %s: only RUN, CMD, COPY, FROM, ARGS supported", cmdline[0], line)
 	}
 
 	return cmd, cmdline[1], nil
@@ -143,12 +143,12 @@ func dispatchArg(layerValue string, ima *v1.Image) {
 	for _, element := range kv {
 		valueLine := strings.SplitN(element, "=", 2)
 		if len(valueLine) != 2 {
-			logrus.Errorf("invalid ARG value %s. ARG format must be key=value", layerValue)
+			logrus.Errorf("invalid ARG value %s: ARG format must be key=value", layerValue)
 			return
 		}
 		k := strings.TrimSpace(valueLine[0])
 		if !strUtils.IsLetterOrNumber(k) {
-			logrus.Errorf("ARG key must be letter or number,invalid ARG format will ignore this key %s.", k)
+			logrus.Errorf("ARG key must be letter or number, invalid ARG format will ignore this key %s", k)
 			return
 		}
 		ima.Spec.ImageConfig.Args.Current[k] = strings.TrimSpace(valueLine[1])

--- a/pkg/plugin/etcd_backup_plugin.go
+++ b/pkg/plugin/etcd_backup_plugin.go
@@ -93,12 +93,12 @@ func connEtcd(masterIP net.IP) (clientv3.Config, error) {
 
 	cert, err := tls.LoadX509KeyPair(etcdCert, etcdCertKey)
 	if err != nil {
-		return clientv3.Config{}, fmt.Errorf("cacert or key file is not exist, err:%v", err)
+		return clientv3.Config{}, fmt.Errorf("failed to load cacert or key file: %v", err)
 	}
 
 	caData, err := ioutil.ReadFile(etcdCa)
 	if err != nil {
-		return clientv3.Config{}, fmt.Errorf("ca certificate reading failed, err:%v", err)
+		return clientv3.Config{}, fmt.Errorf("failed to read ca certificate: %v", err)
 	}
 
 	pool := x509.NewCertPool()
@@ -118,7 +118,7 @@ func connEtcd(masterIP net.IP) (clientv3.Config, error) {
 
 	cli, err := clientv3.New(cfg)
 	if err != nil {
-		return clientv3.Config{}, fmt.Errorf("connect to etcd failed, err:%v", err)
+		return clientv3.Config{}, fmt.Errorf("failed to connect etcd: %v", err)
 	}
 
 	logrus.Info("connect to etcd success")
@@ -131,16 +131,16 @@ func connEtcd(masterIP net.IP) (clientv3.Config, error) {
 func snapshotEtcd(snapshotPath string, cfg clientv3.Config) error {
 	lg, err := zap.NewProduction()
 	if err != nil {
-		return fmt.Errorf("get zap logger error, err:%v", err)
+		return fmt.Errorf("failed to get zap logger: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err := snapshot.Save(ctx, lg, cfg, snapshotPath); err != nil {
-		return fmt.Errorf("snapshot save err: %v", err)
+		return fmt.Errorf("failed to save snapshot: %v", err)
 	}
-	logrus.Infof("Snapshot saved at %s\n", snapshotPath)
+	logrus.Infof("Snapshot saved at %s", snapshotPath)
 
 	return nil
 }

--- a/pkg/plugin/hostname_plugin.go
+++ b/pkg/plugin/hostname_plugin.go
@@ -60,7 +60,7 @@ func (h HostnamePlugin) Run(context Context, phase Phase) error {
 		}
 		err = h.changeNodeName(hostname, net.ParseIP(ip), sshClient)
 		if err != nil {
-			return fmt.Errorf("current cluster nodes hostname change failed, %v", err)
+			return fmt.Errorf("failed to update hostname of current cluster nodes(%s): %v", ip, err)
 		}
 	}
 	return nil
@@ -97,8 +97,8 @@ func (h HostnamePlugin) changeNodeName(hostname string, ip net.IP, SSH ssh.Inter
 	//cmd to change hostname permanently
 	perCMD := fmt.Sprintf(`rm -f /etc/hostname && echo "%s" >> /etc/hostname`, hostname)
 	if err := SSH.CmdAsync(ip, tmpCMD, perCMD); err != nil {
-		return fmt.Errorf("failed to change the node %v hostname,%v", ip, err)
+		return fmt.Errorf("failed to update hostname of node(%s): %v", ip, err)
 	}
-	logrus.Infof("successfully changed node %s hostname to %s.", ip, hostname)
+	logrus.Infof("succeed in updating hostname of node(%s) to %s", ip, hostname)
 	return nil
 }

--- a/pkg/plugin/labels.go
+++ b/pkg/plugin/labels.go
@@ -57,7 +57,7 @@ func (l LabelsNodes) Run(context Context, phase Phase) error {
 
 	nodeList, err := l.client.ListNodes()
 	if err != nil {
-		return fmt.Errorf("current cluster nodes not found, %v", err)
+		return fmt.Errorf("failed to list cluster nodes: %v", err)
 	}
 	for _, v := range nodeList.Items {
 		internalIP := l.getAddress(v.Status.Addresses)
@@ -71,9 +71,9 @@ func (l LabelsNodes) Run(context Context, phase Phase) error {
 			v.SetResourceVersion("")
 
 			if _, err := l.client.UpdateNode(v); err != nil {
-				return fmt.Errorf("current cluster nodes label failed, %v", err)
+				return fmt.Errorf("failed to label current cluster nodes label: %v", err)
 			}
-			logrus.Infof("successfully added node %s labels %v.", internalIP, labels)
+			logrus.Infof("succeed in adding labels(%s) for node(%v)", labels, internalIP)
 		}
 	}
 	return nil

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -72,7 +72,7 @@ func (c *PluginsProcessor) Load() error {
 
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return fmt.Errorf("failed to load plugin dir %v", err)
+		return fmt.Errorf("failed to load plugin dir: %v", err)
 	}
 	for _, f := range files {
 		// load shared object(.so) file
@@ -87,7 +87,7 @@ func (c *PluginsProcessor) Load() error {
 		if yaml.Matcher(f.Name()) {
 			plugins, err := utils.DecodeCRDFromFile(filepath.Join(path, f.Name()), common.Plugin)
 			if err != nil {
-				return fmt.Errorf("failed to load plugin %v", err)
+				return fmt.Errorf("failed to load plugin: %v", err)
 			}
 			var plugs []v1.Plugin
 			for _, p := range plugins.([]v1.Plugin) {

--- a/pkg/plugin/shell_plugin.go
+++ b/pkg/plugin/shell_plugin.go
@@ -73,7 +73,7 @@ func (s Sheller) Run(context Context, phase Phase) (err error) {
 		}
 		err = sshClient.CmdAsync(ip, envProcessor.WrapperShell(ip, pluginCmd))
 		if err != nil {
-			return fmt.Errorf("failed to run shell cmd,  %v", err)
+			return fmt.Errorf("failed to run shell cmd: %v", err)
 		}
 		runPluginIPList = append(runPluginIPList, ip)
 	}

--- a/pkg/plugin/taint_plugin.go
+++ b/pkg/plugin/taint_plugin.go
@@ -95,7 +95,7 @@ func (l *Taint) Run(context Context, phase Phase) (err error) {
 				if err != nil {
 					return err
 				}
-				logrus.Infof("successfully updated node %s taints to %v.", v.Address, updateTaints)
+				logrus.Infof("succeed in updating node(%s) taints to %v", v.Address, updateTaints)
 			}
 			break
 		}

--- a/pkg/runtime/nodes.go
+++ b/pkg/runtime/nodes.go
@@ -173,7 +173,7 @@ func (k *KubeadmRuntime) deleteNode(node net.IP) error {
 		}
 		ssh, err := k.getHostSSHClient(k.GetMaster0IP())
 		if err != nil {
-			return fmt.Errorf("failed to delete node on master0: %v", err)
+			return fmt.Errorf("failed to get master0 ssh client(%s): %v", k.GetMaster0IP(), err)
 		}
 		if err := ssh.CmdAsync(k.GetMaster0IP(), fmt.Sprintf(KubeDeleteNode, strings.TrimSpace(hostname))); err != nil {
 			return fmt.Errorf("failed to delete node %s: %v", hostname, err)

--- a/pkg/runtime/registry.go
+++ b/pkg/runtime/registry.go
@@ -124,7 +124,7 @@ func GetRegistryConfig(rootfs string, defaultRegistryIP net.IP) *RegistryConfig 
 	}
 	err := yaml.UnmarshalFile(registryConfigPath, &config)
 	if err != nil {
-		logrus.Error("Failed to read registry config! ")
+		logrus.Errorf("failed to read registry config: %v", err)
 		return DefaultConfig
 	}
 	if config.IP == nil {

--- a/pkg/runtime/reset.go
+++ b/pkg/runtime/reset.go
@@ -60,7 +60,7 @@ func (k *KubeadmRuntime) resetNodes(nodes []net.IP) {
 func (k *KubeadmRuntime) resetMasters(nodes []net.IP) {
 	for _, node := range nodes {
 		if err := k.resetNode(node); err != nil {
-			logrus.Errorf("delete master %s failed %v", node, err)
+			logrus.Errorf("failed to delete master(%s): %v", node, err)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func (k *KubeadmRuntime) resetMasters(nodes []net.IP) {
 func (k *KubeadmRuntime) resetNode(node net.IP) error {
 	ssh, err := k.getHostSSHClient(node)
 	if err != nil {
-		return fmt.Errorf("reset node failed %v", err)
+		return fmt.Errorf("failed to reset node: %v", err)
 	}
 	if err := ssh.CmdAsync(node, fmt.Sprintf(RemoteCleanMasterOrNode, vlogToStr(k.Vlog)),
 		RemoveKubeConfig,

--- a/pkg/runtime/update_cert.go
+++ b/pkg/runtime/update_cert.go
@@ -42,13 +42,13 @@ func (k *KubeadmRuntime) updateCert(certs []string) error {
 	}
 	clusterConfiguration, ok := obj.(*v1beta2.ClusterConfiguration)
 	if !ok {
-		return fmt.Errorf("get ClusterConfiguration failed")
+		return fmt.Errorf("failed to get ClusterConfiguration")
 	}
 
 	k.setCertSANS(append(clusterConfiguration.APIServer.CertSANs, certs...))
 	ssh, err := k.getHostSSHClient(k.GetMaster0IP())
 	if err != nil {
-		return fmt.Errorf("failed to update cert, %v", err)
+		return fmt.Errorf("failed to update cert: %v", err)
 	}
 	if err := ssh.CmdAsync(k.GetMaster0IP(), "rm -rf /etc/kubernetes/admin.conf"); err != nil {
 		return err
@@ -62,7 +62,7 @@ func (k *KubeadmRuntime) updateCert(certs []string) error {
 
 	for _, f := range pipeline {
 		if err := f(); err != nil {
-			return fmt.Errorf("failed to init master0 %v", err)
+			return fmt.Errorf("failed to init master0: %v", err)
 		}
 	}
 	if err := k.SendJoinMasterKubeConfigs([]net.IP{k.GetMaster0IP()}, AdminConf, ControllerConf, SchedulerConf, KubeletConf); err != nil {

--- a/pkg/runtime/upgrade.go
+++ b/pkg/runtime/upgrade.go
@@ -69,7 +69,7 @@ func (k *KubeadmRuntime) upgradeFirstMaster(IP net.IP, binPath, version string) 
 	}
 	ssh, err := k.getHostSSHClient(IP)
 	if err != nil {
-		return fmt.Errorf("upgrade master0 failed %v", err)
+		return fmt.Errorf("failed to get master0 ssh client: %v", err)
 	}
 	return ssh.CmdAsync(IP, firstMasterCmds...)
 }
@@ -95,7 +95,7 @@ func (k *KubeadmRuntime) upgradeOtherMasters(IPs []net.IP, binpath, version stri
 	for _, ip := range IPs {
 		ssh, err := k.getHostSSHClient(ip)
 		if err != nil {
-			return fmt.Errorf("upgrade other masters failed: %v", err)
+			return fmt.Errorf("failed to get ssh client of host(%s): %v", ip, err)
 		}
 		err = ssh.CmdAsync(ip, otherMasterCmds...)
 		if err != nil {
@@ -116,7 +116,7 @@ func (k *KubeadmRuntime) upgradeNodes(IPs []net.IP, binpath string) error {
 	for _, ip := range IPs {
 		ssh, err := k.getHostSSHClient(ip)
 		if err != nil {
-			return fmt.Errorf("upgrade node failed: %v", err)
+			return fmt.Errorf("failed to get ssh client of host(%s): %v", ip, err)
 		}
 		err = ssh.CmdAsync(ip, nodeCmds...)
 		if err != nil {

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -81,7 +81,7 @@ func GetKubectlAndKubeconfig(ssh ssh.Interface, host net.IP, rootfs string) erro
 		}
 		err = exec.Cmd("chmod", "+x", common.KubectlPath)
 		if err != nil {
-			return errors.Wrap(err, "chmod a+x kubectl failed")
+			return errors.Wrap(err, "failed to chmod a+x kubectl")
 		}
 	}
 	return nil
@@ -99,11 +99,11 @@ func LoadMetadata(rootfs string) (*Metadata, error) {
 
 	metadataFile, err = ioutil.ReadFile(filepath.Clean(metadataPath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read ClusterImage metadata %v", err)
+		return nil, fmt.Errorf("failed to read ClusterImage metadata: %v", err)
 	}
 	err = json.Unmarshal(metadataFile, &md)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load ClusterImage metadata %v", err)
+		return nil, fmt.Errorf("failed to load ClusterImage metadata: %v", err)
 	}
 	return &md, nil
 }

--- a/utils/archive/compress.go
+++ b/utils/archive/compress.go
@@ -267,7 +267,7 @@ func writeToTarWriter(path string, tarWriter *tar.Writer, bufWriter *bufio.Write
 			}
 			defer func() {
 				if err := fHandler.Close(); err != nil {
-					logrus.Fatal("failed to close file")
+					logrus.Errorf("failed to close file: %v", err)
 				}
 			}()
 			bufWriter.Reset(tarWriter)
@@ -384,7 +384,7 @@ func Decompress(src io.Reader, dst string, options Options) (int64, error) {
 
 				defer func() {
 					if err := fileToWrite.Close(); err != nil {
-						logrus.Fatal("failed to close file")
+						logrus.Errorf("failed to close file: %v", err)
 					}
 				}()
 				if _, inErr = io.Copy(fileToWrite, tr); inErr != nil {

--- a/utils/collector/collector.go
+++ b/utils/collector/collector.go
@@ -25,7 +25,7 @@ func NewCollector(src string) (Collector, error) {
 	// if src is detected as remote context,will new different Collector via src type.
 	switch {
 	case src == "":
-		return nil, fmt.Errorf("src can not be nil")
+		return nil, fmt.Errorf("src can not be empty")
 	case IsGitURL(src):
 		// remote git context
 		return NewGitCollector(), nil

--- a/utils/collector/remote_context.go
+++ b/utils/collector/remote_context.go
@@ -61,13 +61,13 @@ func (g gitCollector) Collect(buildContext, src, savePath string) error {
 		privateKeyFile := os.Getenv("HOME") + "/.ssh/id_rsa"
 		_, err := os.Stat(privateKeyFile)
 		if err != nil {
-			logrus.Warnf("read file %s failed %s\n", privateKeyFile, err.Error())
+			logrus.Warnf("failed to read file(%s): %s", privateKeyFile, err.Error())
 			return err
 		}
 
 		publicKeys, err := ssh.NewPublicKeysFromFile("git", privateKeyFile, "")
 		if err != nil {
-			logrus.Warnf("generate public keys failed: %s\n", err.Error())
+			logrus.Warnf("failed to generate public keys: %s", err.Error())
 			return err
 		}
 		co.Auth = publicKeys

--- a/utils/decode.go
+++ b/utils/decode.go
@@ -54,11 +54,11 @@ var decodeCRDFuncMap = map[string]func(reader io.Reader) (interface{}, error){
 func DecodeCRDFromFile(filepath string, kind string) (interface{}, error) {
 	file, err := os.Open(path.Clean(filepath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to dump config %v", err)
+		return nil, fmt.Errorf("failed to open configfile(%s): %v", filepath, err)
 	}
 	defer func() {
 		if err = file.Close(); err != nil {
-			logrus.Warnf("failed to dump config close clusterfile failed %v", err)
+			logrus.Warnf("failed to dump config close clusterfile: %v", err)
 		}
 	}()
 	return decodeCRDFuncMap[kind](file)
@@ -92,7 +92,7 @@ func decodeCRDFromReader(decoder *yaml.YAMLToJSONDecoder, kind string,
 		}
 		metaType := metav1.TypeMeta{}
 		if err := yaml.Unmarshal(ext.Raw, &metaType); err != nil {
-			return nil, fmt.Errorf("decode cluster failed %v", err)
+			return nil, fmt.Errorf("failed to decode cluster: %v", err)
 		}
 		if metaType.Kind != kind {
 			continue
@@ -108,11 +108,11 @@ func decodeCRDFromReader(decoder *yaml.YAMLToJSONDecoder, kind string,
 func DecodeV1ClusterFromFile(filepath string) (*v1.Cluster, error) {
 	file, err := os.Open(path.Clean(filepath))
 	if err != nil {
-		return nil, fmt.Errorf("failed to dump config %v", err)
+		return nil, fmt.Errorf("failed to dump config: %v", err)
 	}
 	defer func() {
 		if err = file.Close(); err != nil {
-			logrus.Warnf("failed to dump config close clusterfile failed %v", err)
+			logrus.Warnf("failed to dump config close clusterfile: %v", err)
 		}
 	}()
 

--- a/utils/mount/default.go
+++ b/utils/mount/default.go
@@ -49,12 +49,12 @@ func (d *Default) Mount(target string, upperDir string, layers ...string) error 
 	for _, layer := range layers {
 		srcInfo, err := os.Stat(layer)
 		if err != nil {
-			return fmt.Errorf("get srcInfo err: %s", err)
+			return fmt.Errorf("failed to get srcInfo: %s", err)
 		}
 		if srcInfo.IsDir() {
 			err := copyDir(layer, target)
 			if err != nil {
-				return fmt.Errorf("copyDir [%s] to [%s] failed: %s", layer, target, err)
+				return fmt.Errorf("failed to copyDir [%s] to [%s]: %s", layer, target, err)
 			}
 		} else {
 			IsExist, err := PathExists(target)
@@ -64,7 +64,7 @@ func (d *Default) Mount(target string, upperDir string, layers ...string) error 
 			if !IsExist {
 				err = os.Mkdir(target, 0666)
 				if err != nil {
-					return fmt.Errorf("mkdir [%s] error %v", target, err)
+					return fmt.Errorf("failed to mkdir [%s]: %v", target, err)
 				}
 			}
 			_file := filepath.Base(layer)
@@ -86,7 +86,7 @@ func copyDir(srcPath string, dstPath string) error {
 	if !IsExist {
 		err = os.Mkdir(dstPath, 0666)
 		if err != nil {
-			return fmt.Errorf("mkdir [%s] error %v", dstPath, err)
+			return fmt.Errorf("failed to mkdir [%s]: %v", dstPath, err)
 		}
 	}
 
@@ -117,11 +117,11 @@ func copyFile(src, dst string) error {
 	// open src file
 	srcFile, err := os.Open(filepath.Clean(src))
 	if err != nil {
-		return fmt.Errorf("open file [%s] failed: %s", src, err)
+		return fmt.Errorf("failed to open file [%s]: %s", src, err)
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 	// create dst file
@@ -131,14 +131,14 @@ func copyFile(src, dst string) error {
 	}
 	defer func() {
 		if err := dstFile.Close(); err != nil {
-			logrus.Fatalf("failed to close file: %v", err)
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 
 	// copy  file
 	_, err = io.Copy(dstFile, srcFile)
 	if err != nil {
-		return fmt.Errorf("copy file err: %s", err)
+		return fmt.Errorf("failed to copy file: %s", err)
 	}
 	return nil
 }
@@ -152,5 +152,5 @@ func PathExists(path string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	}
-	return false, fmt.Errorf("os.Stat(%s) err: %s", path, err)
+	return false, fmt.Errorf("failed to os.Stat(%s): %s", path, err)
 }

--- a/utils/mount/mount_service.go
+++ b/utils/mount/mount_service.go
@@ -49,7 +49,7 @@ type mounter struct {
 func (m mounter) TempMount() error {
 	err := m.driver.Mount(m.TempTarget, m.TempUpper, m.LowLayers...)
 	if err != nil {
-		return fmt.Errorf("failed to mount target %s:%v", m.TempTarget, err)
+		return fmt.Errorf("failed to mount target %s: %v", m.TempTarget, err)
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func (m mounter) TempMount() error {
 func (m mounter) TempUMount() error {
 	err := m.driver.Unmount(m.TempTarget)
 	if err != nil {
-		return fmt.Errorf("failed to umount target %s:%v", m.TempTarget, err)
+		return fmt.Errorf("failed to umount target %s: %v", m.TempTarget, err)
 	}
 	return nil
 }
@@ -72,7 +72,7 @@ func (m mounter) CleanUp() {
 
 	err = m.fs.RemoveAll(m.TempUpper, m.TempTarget)
 	if err != nil {
-		logrus.Warnf("failed to delete %s,%s: %v", m.TempUpper, m.TempTarget, err)
+		logrus.Warnf("failed to delete %s and %s: %v", m.TempUpper, m.TempTarget, err)
 	}
 }
 
@@ -94,21 +94,21 @@ func NewMountService(target, upper string, lowLayers []string) (Service, error) 
 	if len(lowLayers) == 0 {
 		tmp, err := f.MkTmpdir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create tmp lower %s:%v", tmp, err)
+			return nil, fmt.Errorf("failed to create tmp lower %s: %v", tmp, err)
 		}
 		lowLayers = append(lowLayers, tmp)
 	}
 	if target == "" {
 		tmp, err := f.MkTmpdir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create tmp target %s:%v", tmp, err)
+			return nil, fmt.Errorf("failed to create tmp target %s: %v", tmp, err)
 		}
 		target = tmp
 	}
 	if upper == "" {
 		tmp, err := f.MkTmpdir()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create tmp upper %s:%v", tmp, err)
+			return nil, fmt.Errorf("failed to create tmp upper %s: %v", tmp, err)
 		}
 		upper = tmp
 	}

--- a/utils/mount/overlay2.go
+++ b/utils/mount/overlay2.go
@@ -56,7 +56,7 @@ func supportsOverlay() bool {
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 	s := bufio.NewScanner(f)
@@ -78,7 +78,7 @@ func (o *Overlay2) Mount(target string, upperLayer string, layers ...string) err
 	}
 	workdir := path.Join(target, "work")
 	if err := os.MkdirAll(workdir, os.ModePerm); err != nil {
-		return fmt.Errorf("create workdir failed")
+		return fmt.Errorf("failed to create workdir: %v", err)
 	}
 	var err error
 	defer func() {
@@ -102,7 +102,7 @@ func (o *Overlay2) Mount(target string, upperLayer string, layers ...string) err
 	mountData := fmt.Sprintf("%slowerdir=%s,upperdir=%s,workdir=%s", indexOff, strings.Join(strUtils.Reverse(layers), ":"), upperLayer, workdir)
 	logrus.Debugf("mount data : %s", mountData)
 	if err = mount("overlay", target, "overlay", 0, mountData); err != nil {
-		return fmt.Errorf("error creating overlay mount to %s: %v", target, err)
+		return fmt.Errorf("failed to create overlay mount to %s: %v", target, err)
 	}
 	return nil
 }

--- a/utils/net/iputils.go
+++ b/utils/net/iputils.go
@@ -66,7 +66,7 @@ func GetHostNetInterface(host net.IP) (string, error) {
 		}
 		addrs, err := netInterfaces[i].Addrs()
 		if err != nil {
-			return "", fmt.Errorf("failed to get Addrs, %v", err)
+			return "", fmt.Errorf("failed to get Addrs: %v", err)
 		}
 		if IsLocalIP(host, addrs) {
 			return netInterfaces[i].Name, nil
@@ -78,9 +78,9 @@ func GetHostNetInterface(host net.IP) (string, error) {
 func GetLocalHostAddresses() ([]net.Addr, error) {
 	netInterfaces, err := net.Interfaces()
 	if err != nil {
-		fmt.Println("net.Interfaces failed, err:", err.Error())
-		return nil, err
+		return nil, fmt.Errorf("failed to get net.Interfaces: %v", err)
 	}
+
 	var allAddrs []net.Addr
 	for i := 0; i < len(netInterfaces); i++ {
 		if (netInterfaces[i].Flags & net.FlagUp) == 0 {
@@ -88,7 +88,7 @@ func GetLocalHostAddresses() ([]net.Addr, error) {
 		}
 		addrs, err := netInterfaces[i].Addrs()
 		if err != nil {
-			fmt.Printf("failed to get Addrs, %s", err.Error())
+			return nil, fmt.Errorf("failed to get Addrs: %v", err)
 		}
 		for j := 0; j < len(addrs); j++ {
 			allAddrs = append(allAddrs, addrs[j])

--- a/utils/net/route.go
+++ b/utils/net/route.go
@@ -105,7 +105,7 @@ func (r *Route) DelRoute() error {
 	}
 	err := delRouteGatewayViaHost(r.Host, r.Gateway)
 	if err != nil && !errors.Is(err, syscall.ESRCH) /* return if route does not exist */ {
-		return fmt.Errorf("failed to delete %s route gateway via host err: %v", r.Host, err)
+		return fmt.Errorf("failed to delete %s route gateway via host: %v", r.Host, err)
 	}
 	netInterface, err := GetHostNetInterface(r.Gateway)
 	if err != nil {
@@ -119,7 +119,7 @@ func (r *Route) DelRoute() error {
 			return err
 		}
 	}
-	logrus.Info(fmt.Sprintf("success to del route.(host:%s, gateway:%s)", r.Host, r.Gateway))
+	logrus.Info(fmt.Sprintf("success to del route(host:%s, gateway:%s)", r.Host, r.Gateway))
 	return nil
 }
 

--- a/utils/os/fs.go
+++ b/utils/os/fs.go
@@ -41,7 +41,7 @@ func CountDirFiles(dirName string) int {
 		return nil
 	})
 	if err != nil {
-		logrus.Warnf("count dir files failed %v", err)
+		logrus.Warnf("failed to count dir files: %v", err)
 		return 0
 	}
 	return count

--- a/utils/os/fs/filesystem.go
+++ b/utils/os/fs/filesystem.go
@@ -53,7 +53,7 @@ func (f filesystem) RemoveAll(path ...string) error {
 	for _, fi := range path {
 		err := os.RemoveAll(fi)
 		if err != nil {
-			return fmt.Errorf("failed to clean file %s, %v", fi, err)
+			return fmt.Errorf("failed to clean file %s: %v", fi, err)
 		}
 	}
 	return nil
@@ -128,7 +128,7 @@ func (f filesystem) CopyFile(src, dst string) (int64, error) {
 	}
 	defer func() {
 		if err := source.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 	//will overwrite dst when dst is existed
@@ -138,7 +138,7 @@ func (f filesystem) CopyFile(src, dst string) (int64, error) {
 	}
 	defer func() {
 		if err := destination.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 	err = destination.Chmod(sourceFileStat.Mode())

--- a/utils/os/readers.go
+++ b/utils/os/readers.go
@@ -74,7 +74,7 @@ func (r fileReader) ReadAll() ([]byte, error) {
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			logrus.Fatal("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 

--- a/utils/platform/cpu.go
+++ b/utils/platform/cpu.go
@@ -69,7 +69,7 @@ func getCPUInfo(pattern string) (info string, err error) {
 	}
 	defer func() {
 		if err := cpuinfo.Close(); err != nil {
-			logrus.Error("failed to close file")
+			logrus.Errorf("failed to close file: %v", err)
 		}
 	}()
 

--- a/utils/ssh/connect.go
+++ b/utils/ssh/connect.go
@@ -173,7 +173,7 @@ func (s *SSH) NewSudoSftpClient(conn *ssh.Client, opts ...sftp.ClientOption) (*s
 	cmd = `grep -oP "Subsystem\s+sftp\s+\K.*" /etc/ssh/sshd_config`
 	buff, err = ses2.Output(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("cmd output errored %v", err)
+		return nil, fmt.Errorf("failed to execute cmd(%s): %v", cmd, err)
 	}
 
 	ses, err = conn.NewSession()
@@ -188,7 +188,7 @@ func (s *SSH) NewSudoSftpClient(conn *ssh.Client, opts ...sftp.ClientOption) (*s
 
 	ok, err := ses.SendRequest("exec", true, ssh.Marshal(struct{ Command string }{sftpServerPath}))
 	if err == nil && !ok {
-		return nil, errors.New("ssh: exec request failed")
+		return nil, errors.New("ssh: failed to exec request")
 	}
 
 	pw, err := ses.StdinPipe()

--- a/utils/ssh/platform.go
+++ b/utils/ssh/platform.go
@@ -71,7 +71,7 @@ func (s *SSH) Platform(host net.IP) (v1.Platform, error) {
 func (s *SSH) getCPUInfo(host net.IP, pattern string) (info string, err error) {
 	sshClient, sftpClient, err := s.sftpConnect(host)
 	if err != nil {
-		return "", fmt.Errorf("new sftp client failed %v", err)
+		return "", fmt.Errorf("failed to new sftp client: %v", err)
 	}
 	defer func() {
 		_ = sftpClient.Close()
@@ -80,7 +80,7 @@ func (s *SSH) getCPUInfo(host net.IP, pattern string) (info string, err error) {
 	// open remote source file
 	srcFile, err := sftpClient.Open("/proc/cpuinfo")
 	if err != nil {
-		return "", fmt.Errorf("open /proc/cpuinfo file failed %v", err)
+		return "", fmt.Errorf("failed to open /proc/cpuinfo: %v", err)
 	}
 	defer func() {
 		if err := srcFile.Close(); err != nil {

--- a/utils/ssh/ssh.go
+++ b/utils/ssh/ssh.go
@@ -98,7 +98,7 @@ func GetHostSSHClient(hostIP net.IP, cluster *v2.Cluster) (Interface, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("get host ssh client failed, host ip %s not in hosts ip list", hostIP)
+	return nil, fmt.Errorf("failed to get host ssh client: host ip %s not in hosts ip list", hostIP)
 }
 
 // NewStdoutSSHClient is used to show std out when execute bash command.
@@ -113,5 +113,5 @@ func NewStdoutSSHClient(hostIP net.IP, cluster *v2.Cluster) (Interface, error) {
 			}
 		}
 	}
-	return nil, fmt.Errorf("get host ssh client failed, host ip %s not in hosts ip list", hostIP)
+	return nil, fmt.Errorf("failed to get host ssh client: host ip %s not in hosts ip list", hostIP)
 }

--- a/utils/ssh/sshcmd.go
+++ b/utils/ssh/sshcmd.go
@@ -34,7 +34,7 @@ func (s *SSH) Ping(host net.IP) error {
 	}
 	client, _, err := s.Connect(host)
 	if err != nil {
-		return fmt.Errorf("[ssh %s]create ssh session failed, %v", host, err)
+		return fmt.Errorf("[ssh %s] failed to create ssh session: %v", host, err)
 	}
 	err = client.Close()
 	if err != nil {
@@ -152,7 +152,7 @@ func (s *SSH) CmdToString(host net.IP, cmd, split string) (string, error) {
 	data, err := s.Cmd(host, cmd)
 	str := string(data)
 	if err != nil {
-		return str, fmt.Errorf("exec command failed %s %s %v", host, cmd, err)
+		return str, fmt.Errorf("failed to exec command(%s) on host(%s): %v", cmd, host, err)
 	}
 	if data != nil {
 		str = strings.ReplaceAll(str, "\r\n", split)

--- a/utils/ssh/utils.go
+++ b/utils/ssh/utils.go
@@ -128,7 +128,7 @@ func WaitSSHReady(ssh Interface, tryTimes int, hosts ...net.IP) error {
 				}
 				time.Sleep(time.Duration(i) * time.Second)
 			}
-			return fmt.Errorf("wait for [%s] ssh ready timeout:  %v, ensure that the IP address or password is correct", host, err)
+			return fmt.Errorf("wait for [%s] ssh ready timeout: %v, ensure that the IP address or password is correct", host, err)
 		})
 	}
 	return eg.Wait()


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

### Describe what this PR does / why we need it

This pull request updated area of sealer's log. 

Currently, end users bear a lot on sealer's log. There are lots of cases where end user could not recognize the log's meaning, even if he is a senior k8s or sealer engineer. We have to say sealer's log needs improvement. 

First, just make the error message and log message readable, to satisfy normal user's English reading.
Second, provide helpful information as sufficient as possible. 

And This pull request went through all log and error code of sealer project, and improved them within itself.

In the future, we still keep pace with user's input to improve log and error, such as: improving the accurate embedded message, shorten log information with continuous arch improving.
 
### Does this pull request fix one issue?
none
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
none