### PR TITLE
bugfix: delete empty ip string which will be added to api server cert alt name

### DIFF
--- a/apply/scale.go
+++ b/apply/scale.go
@@ -32,17 +32,27 @@ import (
 
 // NewScaleApplierFromArgs will filter ip list from command parameters.
 func NewScaleApplierFromArgs(clusterfile string, scaleArgs *Args, flag string) (applydriver.Interface, error) {
+	if scaleArgs.Nodes == "" && scaleArgs.Masters == "" {
+		return nil, fmt.Errorf("master and node cannot both be empty")
+	}
+
+	// validate input masters IP info
+	if len(scaleArgs.Masters) != 0 {
+		if err := validateIPStr(scaleArgs.Masters); err != nil {
+			return nil, fmt.Errorf("failed to validate input scale masters ip: %v", err)
+		}
+	}
+
+	// validate input nodes IP info
+	if len(scaleArgs.Nodes) != 0 {
+		if err := validateIPStr(scaleArgs.Nodes); err != nil {
+			return nil, fmt.Errorf("failed to validate input scale nodes ip: %v", err)
+		}
+	}
+
 	cluster := &v2.Cluster{}
 	if err := yaml.UnmarshalFile(clusterfile, cluster); err != nil {
 		return nil, err
-	}
-
-	if err := validateArgs(scaleArgs); err != nil {
-		return nil, fmt.Errorf("failed to validate input scale args: %v", err)
-	}
-
-	if scaleArgs.Nodes == "" && scaleArgs.Masters == "" {
-		return nil, fmt.Errorf("master and node cannot both be empty")
 	}
 
 	var err error

--- a/apply/scale_test.go
+++ b/apply/scale_test.go
@@ -91,6 +91,42 @@ func TestNewCleanApplierFromArgs(t *testing.T) {
 			common.DeleteSubCmd,
 			true,
 		},
+		{
+			"Clusterfile",
+			&Args{
+				Masters: "10.110.101.1,10.110.101.2",
+			},
+			"join only has master",
+			common.JoinSubCmd,
+			false,
+		},
+
+		{
+			"Clusterfile",
+			&Args{
+				Nodes: "10.110.101.1,10.110.101.2",
+			},
+			"join only has node",
+			common.JoinSubCmd,
+			false,
+		},
+		{
+			"Clusterfile",
+			&Args{
+				Masters: "10.110.101.1,10.110.101.2",
+				Nodes:   "10.110.101.1,10.110.101.2",
+			},
+			"join master and node at the same time",
+			common.JoinSubCmd,
+			false,
+		},
+		{
+			"Clusterfile",
+			&Args{},
+			"joined master and node are both empty",
+			common.JoinSubCmd,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -75,13 +75,13 @@ func (in *Cluster) GetMasterIPList() []net.IP {
 	return in.GetIPSByRole(common.MASTER)
 }
 
-func (in *Cluster) GetMasterIPStrList() []string {
+func (in *Cluster) GetMasterIPStrList() (ipStrList []string) {
 	ipList := in.GetIPSByRole(common.MASTER)
 
-	ipStrList := make([]string, len(ipList))
 	for _, ip := range ipList {
 		ipStrList = append(ipStrList, ip.String())
 	}
+
 	return ipStrList
 }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. `make` will add default value  "" as one element , while  empty string is meaningful for k8s api server alt name cert.
thus, it will fail to run `kubeadm init`.
2. skip validate masters ip if only scale up node.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
