### PR TITLE
fix: add default length for slice

### DIFF
--- a/apply/run.go
+++ b/apply/run.go
@@ -110,7 +110,7 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 	}
 
 	masters := strings.Split(inMasters, ",")
-	masterHosts := make([]v2.Host, len(masters))
+	masterHosts := make([]v2.Host, 0, len(masters))
 	for index, master := range masters {
 		if index == 0 {
 			// only master0 should add two roles: master and master0
@@ -135,7 +135,7 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 	// if inNodes is empty,Split will return a slice of length 1 whose only element is inNodes.
 	// so we need to filter the empty string to make sure the cluster node ip is valid.
 	nodes := strings.Split(inNodes, ",")
-	nodeHosts := make([]v2.Host, len(nodes))
+	nodeHosts := make([]v2.Host, 0, len(nodes))
 	for _, node := range nodes {
 		if node != "" {
 			nodeHosts = append(nodeHosts, v2.Host{
@@ -145,7 +145,7 @@ func getHosts(inMasters, inNodes string) ([]v2.Host, error) {
 		}
 	}
 
-	result := make([]v2.Host, len(masters)+len(nodes))
+	result := make([]v2.Host, 0, len(masters)+len(nodes))
 	result = append(result, masterHosts...)
 	result = append(result, nodeHosts...)
 

--- a/pkg/debug/clusterinfo/clusterinfo.go
+++ b/pkg/debug/clusterinfo/clusterinfo.go
@@ -78,12 +78,11 @@ func GetDNSServiceAll(ctx context.Context, client corev1client.CoreV1Interface) 
 	return domain, serviceClusterIP, endpointsIPs, nil
 }
 
-func removeDuplicatesAndEmpty(ss []string) []string {
+func removeDuplicatesAndEmpty(ss []string) (res []string) {
 	if len(ss) == 0 {
 		return ss
 	}
 
-	res := make([]string, len(ss))
 	sMap := map[string]bool{}
 
 	for _, v := range ss {

--- a/utils/net/iputils.go
+++ b/utils/net/iputils.go
@@ -192,7 +192,7 @@ func DisassembleIPList(arg string) []net.IP {
 		res = append(res, i)
 	}
 
-	resIP := make([]net.IP, len(res))
+	resIP := make([]net.IP, 0, len(res))
 	for _, ip := range res {
 		resIP = append(resIP, net.ParseIP(ip))
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Usually , we use builtin func `make` to allocates and initializes a slice with the type and the length.

golang will init the default value of the slice type with the length and the capacity .

examples: `make([]string,2)`  that means we got a slice ["",""] which length and capacity both equal 2.

after do `append`, the length will grow, but If  it has no sufficient capacity,  a new underlying array will be allocated with the new length and capacity. then, the new slice  looks like : `["","","test"]` with length and capacity equal 3.

so, in some case ,  if the default value is meaningful , it will cause some uncontrollable bug.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

set the slice with default length 0, append will start form the length index.

Or use `var ` to declare a variable.

### Describe how to verify it


### Special notes for reviews
