### PR TITLE
Add optional parameters when building an image

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -28,25 +28,27 @@ type Interface interface {
 
 func NewBuilder(config *Config) (Interface, error) {
 	return &liteBuilder{
-		noCache:   config.NoCache,
-		noBase:    config.NoBase,
-		buildArgs: config.BuildArgs,
-		platform:  config.Platform,
+		noCache:       config.NoCache,
+		noBase:        config.NoBase,
+		buildArgs:     config.BuildArgs,
+		platform:      config.Platform,
+		downloadImage: config.DownloadImage,
 	}, nil
 }
 
 type liteBuilder struct {
-	noCache      bool
-	noBase       bool
-	imageNamed   reference.Named
-	context      string
-	kubeFileName string
-	buildArgs    map[string]string
-	baseLayers   []v1.Layer
-	rawImage     *v1.Image
-	platform     v1.Platform
-	executor     buildimage.Executor
-	saver        buildimage.ImageSaver
+	noCache       bool
+	noBase        bool
+	downloadImage bool
+	imageNamed    reference.Named
+	context       string
+	kubeFileName  string
+	buildArgs     map[string]string
+	baseLayers    []v1.Layer
+	rawImage      *v1.Image
+	platform      v1.Platform
+	executor      buildimage.Executor
+	saver         buildimage.ImageSaver
 }
 
 func (l liteBuilder) Build(name string, context string, kubefileName string) error {
@@ -118,9 +120,10 @@ func (l liteBuilder) ExecBuild() error {
 	}
 
 	ctx := buildimage.Context{
-		BuildContext: l.context,
-		UseCache:     !l.noCache,
-		BuildArgs:    l.rawImage.Spec.ImageConfig.Args.Current,
+		BuildContext:  l.context,
+		UseCache:      !l.noCache,
+		BuildArgs:     l.rawImage.Spec.ImageConfig.Args.Current,
+		DownloadImage: l.downloadImage,
 	}
 
 	layers, err := l.executor.Execute(ctx, l.rawImage.Spec.Layers[1:])

--- a/build/buildimage/config.go
+++ b/build/buildimage/config.go
@@ -17,8 +17,9 @@ package buildimage
 type Context struct {
 	BuildContext string
 	//cache flag,will change for each layer ctx
-	UseCache  bool
-	BuildArgs map[string]string
+	UseCache      bool
+	DownloadImage bool
+	BuildArgs     map[string]string
 }
 
 type SaveOpts struct {

--- a/build/buildimage/executor.go
+++ b/build/buildimage/executor.go
@@ -50,8 +50,7 @@ func (l *layerExecutor) Execute(ctx Context, rawLayers []v1.Layer) ([]v1.Layer, 
 	)
 
 	// process middleware file
-	err := l.checkMiddleware(ctx.BuildContext)
-	if err != nil {
+	if err := l.checkMiddleware(ctx.BuildContext); err != nil {
 		return []v1.Layer{}, err
 	}
 
@@ -96,9 +95,10 @@ func (l *layerExecutor) Execute(ctx Context, rawLayers []v1.Layer) ([]v1.Layer, 
 	logrus.Info("exec all build instructs success")
 
 	// process differ of manifests and metadata.
-	err = l.checkDiff(rawLayers)
-	if err != nil {
-		return []v1.Layer{}, err
+	if ctx.DownloadImage {
+		if err := l.checkDiff(rawLayers); err != nil {
+			return []v1.Layer{}, err
+		}
 	}
 
 	upper := l.rootfsMountInfo.GetMountUpper()

--- a/build/config.go
+++ b/build/config.go
@@ -17,10 +17,11 @@ package build
 import v1 "github.com/sealerio/sealer/types/api/v1"
 
 type Config struct {
-	BuildType string
-	NoCache   bool
-	NoBase    bool
-	ImageName string
-	BuildArgs map[string]string
-	Platform  v1.Platform
+	BuildType     string
+	NoCache       bool
+	NoBase        bool
+	DownloadImage bool
+	ImageName     string
+	BuildArgs     map[string]string
+	Platform      v1.Platform
 }

--- a/cmd/sealer/cmd/build.go
+++ b/cmd/sealer/cmd/build.go
@@ -97,7 +97,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "ClusterImage build type, default is lite")
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "Kubefile filepath")
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "the name of ClusterImage")
-	buildCmd.Flags().BoolVar(&buildConfig.DownloadImage, "downloadImage", true, "download manifest image")
+	buildCmd.Flags().BoolVar(&buildConfig.DownloadImage, "save-app-image", true, "build with application container image, default value is true")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
 	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image, default value is true")
 	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build args")

--- a/cmd/sealer/cmd/build.go
+++ b/cmd/sealer/cmd/build.go
@@ -26,13 +26,14 @@ import (
 )
 
 type BuildFlag struct {
-	ImageName    string
-	KubefileName string
-	BuildType    string
-	BuildArgs    []string
-	Platform     string
-	NoCache      bool
-	Base         bool
+	ImageName     string
+	KubefileName  string
+	BuildType     string
+	BuildArgs     []string
+	Platform      string
+	NoCache       bool
+	Base          bool
+	DownloadImage bool
 }
 
 var buildConfig *BuildFlag
@@ -69,12 +70,13 @@ build with args:
 		for _, tp := range targetPlatforms {
 			p := tp
 			conf := &build.Config{
-				BuildType: buildConfig.BuildType,
-				NoCache:   buildConfig.NoCache,
-				ImageName: buildConfig.ImageName,
-				NoBase:    !buildConfig.Base,
-				BuildArgs: strings.ConvertToMap(buildConfig.BuildArgs),
-				Platform:  *p,
+				BuildType:     buildConfig.BuildType,
+				NoCache:       buildConfig.NoCache,
+				ImageName:     buildConfig.ImageName,
+				NoBase:        !buildConfig.Base,
+				BuildArgs:     strings.ConvertToMap(buildConfig.BuildArgs),
+				DownloadImage: buildConfig.DownloadImage,
+				Platform:      *p,
 			}
 			builder, err := build.NewBuilder(conf)
 			if err != nil {
@@ -95,8 +97,9 @@ func init() {
 	buildCmd.Flags().StringVarP(&buildConfig.BuildType, "mode", "m", "lite", "ClusterImage build type, default is lite")
 	buildCmd.Flags().StringVarP(&buildConfig.KubefileName, "kubefile", "f", "Kubefile", "Kubefile filepath")
 	buildCmd.Flags().StringVarP(&buildConfig.ImageName, "imageName", "t", "", "the name of ClusterImage")
+	buildCmd.Flags().BoolVar(&buildConfig.DownloadImage, "downloadImage", true, "download manifest image")
 	buildCmd.Flags().BoolVar(&buildConfig.NoCache, "no-cache", false, "build without cache")
-	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image, default value is true.")
+	buildCmd.Flags().BoolVar(&buildConfig.Base, "base", true, "build with base image, default value is true")
 	buildCmd.Flags().StringSliceVar(&buildConfig.BuildArgs, "build-arg", []string{}, "set custom build args")
 	buildCmd.Flags().StringVar(&buildConfig.Platform, "platform", "", "set ClusterImage platform. If not set, keep same platform with runtime")
 

--- a/utils/yaml/yaml.go
+++ b/utils/yaml/yaml.go
@@ -33,8 +33,7 @@ func UnmarshalFile(file string, obj interface{}) error {
 		return err
 	}
 
-	err = yaml.Unmarshal(data, obj)
-	if err != nil {
+	if err = yaml.Unmarshal(data, obj); err != nil {
 		return fmt.Errorf("failed to unmarshal file %s to %s: %v", file, reflect.TypeOf(obj), err)
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add new flag `--downloadImage` when for command `sealer build`.

The effect of this command: When --downloadImage is true, the image of manifests and charts package will be cached, and when it is false, it will not be cached,the default is true

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

sealer build -f Kubefile -t test:1.1 --downloadImage=false .

### Describe how to verify it


### Special notes for reviews
