### PR TITLE
optimize: build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright © 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION=1.18.5
+
+ARG BASE_DEBIAN_DISTRO="buster"
+ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
+
+FROM ${GOLANG_IMAGE} AS base
+RUN apt update \
+    && apt -y install btrfs-tools libdevmapper-dev libgpgme11-dev
+

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ linux: clean ## build binaries for linux
 	@echo "build sealer and seautil bin for linux"
 	GOOS=linux GOARCH=amd64 hack/build.sh $(GitTag)
 
+# sealer should be compiled in linux platform, otherwise there will be GraphDriver problem.
+build-in-docker:
+	docker run --rm -v ${PWD}:/usr/src/sealer -w /usr/src/sealer registry.cn-qingdao.aliyuncs.com/sealer-io/sealer-build:v1 make linux
+
 test-sealer:
 	@echo "run e2e test for sealer bin"
 	hack/test-sealer.sh


### PR DESCRIPTION
This pr implements building in docker.
Q: Why we need this?
A: Sealer must be built on linux. Otherwise there will be storage problem.

<img width="952" alt="截屏2022-08-15 20 58 45" src="https://user-images.githubusercontent.com/38838049/184639325-5e5ef50f-44a1-4b70-b082-910cf7a21156.png">
