### PR TITLE
bugfix: fix runtime wrong config when join node

### DIFF
--- a/pkg/runtime/kubernetes/join_nodes.go
+++ b/pkg/runtime/kubernetes/join_nodes.go
@@ -49,6 +49,8 @@ func (k *Runtime) joinNodeConfig(nodeIP net.IP) ([]byte, error) {
 		return nil, err
 	}
 	k.setCgroupDriver(cGroupDriver)
+	// bugfix: default
+	k.JoinConfiguration.NodeRegistration.CRISocket = k.InitConfiguration.NodeRegistration.CRISocket
 	return yaml.MarshalWithDelimiter(k.JoinConfiguration, k.KubeletConfiguration)
 }
 

--- a/pkg/runtime/kubernetes/join_nodes.go
+++ b/pkg/runtime/kubernetes/join_nodes.go
@@ -49,7 +49,7 @@ func (k *Runtime) joinNodeConfig(nodeIP net.IP) ([]byte, error) {
 		return nil, err
 	}
 	k.setCgroupDriver(cGroupDriver)
-	// bugfix: default
+	// bugfix: keep the same CRISocket with InitConfiguration
 	k.JoinConfiguration.NodeRegistration.CRISocket = k.InitConfiguration.NodeRegistration.CRISocket
 	return yaml.MarshalWithDelimiter(k.JoinConfiguration, k.KubeletConfiguration)
 }

--- a/pkg/runtime/kubernetes/registry.go
+++ b/pkg/runtime/kubernetes/registry.go
@@ -24,7 +24,7 @@ const (
 	SeaHub                      = "sea.hub"
 	DefaultRegistryHtPasswdFile = "registry_htpasswd"
 	DockerLoginCommand          = "nerdctl login -u %s -p %s %s && " + KubeletAuthCommand
-	KubeletAuthCommand          = "cp /root/.docker/config.json /var/lib/kubelet"
+	KubeletAuthCommand          = "mkdir -p /var/lib/kubelet && cp /root/.docker/config.json /var/lib/kubelet"
 	DeleteRegistryCommand       = "if docker inspect %s 2>/dev/null;then docker rm -f %[1]s;fi && ((! nerdctl ps -a 2>/dev/null |grep %[1]s) || (nerdctl stop %[1]s && nerdctl rmi -f %[1]s))"
 )
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1.fix runtime wrong config when join node: wrong kubeadm config when join node, seems this using default config when merging kubeadm.yaml `criSocket: /var/run/dockershim.sock`
2.  wrong kubelet auth file path: if /var/lib/kubelet is not exist, /var/lib/kubelet will be a file with config.json as its content. that will cause 401 .



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
