### PR TITLE
optimization: be rigorous when check if kubectl command exists

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -55,7 +55,7 @@ const (
 	DefaultRegistryAuthDir        = "/root/.docker/config.json"
 	KubeAdminConf                 = "/etc/kubernetes/admin.conf"
 	DefaultKubeDir                = "/root/.kube"
-	KubectlPath                   = "/usr/bin/kubectl"
+	DefaultKubectlPath            = "/usr/bin/kubectl"
 	EtcHosts                      = "/etc/hosts"
 	ClusterWorkDir                = "/root/.sealer/%s"
 	RemoteSealerPath              = "/usr/local/bin/sealer"

--- a/pkg/filesystem/cloudfilesystem/utils.go
+++ b/pkg/filesystem/cloudfilesystem/utils.go
@@ -67,5 +67,5 @@ func copyRegistry(regIP net.IP, cluster *v2.Cluster, mountDir map[string]bool, t
 
 func CleanFilesystem(clusterName string) error {
 	return fs.NewFilesystem().RemoveAll(common.GetClusterWorkDir(clusterName), common.DefaultClusterBaseDir(clusterName),
-		common.DefaultKubeConfigDir(), common.KubectlPath)
+		common.DefaultKubeConfigDir(), common.DefaultKubectlPath)
 }

--- a/pkg/runtime/kubernetes/utils.go
+++ b/pkg/runtime/kubernetes/utils.go
@@ -43,12 +43,12 @@ func GetKubectlAndKubeconfig(ssh ssh.Interface, host net.IP, rootfs string) erro
 		return errors.Wrap(err, "failed to add master IP to etc hosts")
 	}
 
-	if !osi.IsFileExist(common.KubectlPath) {
-		err = osi.RecursionCopy(filepath.Join(rootfs, "bin/kubectl"), common.KubectlPath)
+	if !osi.IsCommandExist("kubectl") {
+		err = osi.RecursionCopy(filepath.Join(rootfs, "bin/kubectl"), common.DefaultKubectlPath)
 		if err != nil {
 			return err
 		}
-		err = exec.Cmd("chmod", "+x", common.KubectlPath)
+		err = exec.Cmd("chmod", "+x", common.DefaultKubectlPath)
 		if err != nil {
 			return errors.Wrap(err, "failed to chmod a+x kubectl")
 		}

--- a/utils/os/fs.go
+++ b/utils/os/fs.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 
@@ -29,6 +30,11 @@ import (
 func IsFileExist(fileName string) bool {
 	_, err := os.Stat(fileName)
 	return err == nil || os.IsExist(err)
+}
+
+func IsCommandExist(cmdName string) bool {
+	_, err := exec.LookPath(cmdName)
+	return err == nil
 }
 
 func CountDirFiles(dirName string) int {


### PR DESCRIPTION
Part of #1607.

Use exec.LookPath() to search kubectl binary globally on the system,
this command may not be installed under `/usr/bin` by default.

Signed-off-by: Yuanhong Peng <yummypeng@linux.alibaba.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
