### PR TITLE
change sealer default version to "unknown" instead of "latest".

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,7 +42,7 @@ debug() {
 }
 
 get_version_vars() {
-  GIT_VERSION=latest
+  GIT_VERSION=unknown
   if [[ $GIT_TAG ]]; then
     GIT_VERSION=$GIT_TAG
   fi


### PR DESCRIPTION
# Current
sealer version
```
{"gitVersion":"latest","gitCommit":"45787f39","buildDate":"2022-08-25 08:01:37","goVersion":"go1.18.5","compiler":"gc","platform":"linux/amd64"}
```
# My expectation
```
{"gitVersion":"unknown","gitCommit":"45787f39","buildDate":"2022-08-25 08:01:37","goVersion":"go1.18.5","compiler":"gc","platform":"linux/amd64"}
```