### PR TITLE
Fix: overlay umount error by mountpoint

### DIFF
--- a/pkg/prune/build_pruner.go
+++ b/pkg/prune/build_pruner.go
@@ -17,7 +17,6 @@ package prune
 import (
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/utils/mount"
-	osi "github.com/sealerio/sealer/utils/os"
 )
 
 type buildPrune struct {
@@ -33,10 +32,7 @@ func NewBuildPrune() Pruner {
 func (b buildPrune) Select() ([]string, error) {
 	var pruneList []string
 	// umount all tmp dir, and delete it
-	pruneUnits, err := osi.GetDirNameListInDir(b.pruneRootDir, osi.FilterOptions{
-		All:          true,
-		WithFullPath: true,
-	})
+	pruneUnits, err := mount.GetDirNameListInDir(b.pruneRootDir)
 	if err != nil {
 		return pruneList, err
 	}

--- a/utils/mount/mount_service.go
+++ b/utils/mount/mount_service.go
@@ -19,12 +19,12 @@ import (
 	"net"
 	"strings"
 
+	"github.com/moby/sys/mountinfo"
+	"github.com/sealerio/sealer/utils/ssh"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/sirupsen/logrus"
 
-	"github.com/sealerio/sealer/utils/exec"
 	"github.com/sealerio/sealer/utils/os/fs"
-	"github.com/sealerio/sealer/utils/ssh"
 	strUtils "github.com/sealerio/sealer/utils/strings"
 )
 
@@ -120,6 +120,18 @@ func NewMountService(target, upper string, lowLayers []string) (Service, error) 
 	}, nil
 }
 
+func GetDirNameListInDir(dir string) ([]string, error) {
+	var dirs []string
+	infos, err := mountinfo.GetMounts(mountinfo.PrefixFilter(dir))
+	if err != nil {
+		return dirs, err
+	}
+	for _, info := range infos {
+		dirs = append(dirs, info.Mountpoint)
+	}
+	return dirs, nil
+}
+
 //NewMountServiceByTarget will filter file system by target,if not existed,return false.
 func NewMountServiceByTarget(target string) Service {
 	mounted, info := GetMountDetails(target)
@@ -141,12 +153,11 @@ type Info struct {
 }
 
 func GetMountDetails(target string) (bool, *Info) {
-	cmd := fmt.Sprintf("mount | grep %s", target)
-	result, err := exec.RunSimpleCmd(cmd)
+	infos, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(target))
 	if err != nil {
 		return false, nil
 	}
-	return mountCmdResultSplit(result, target)
+	return mountCmdResultSplit(infos[0].VFSOptions, target)
 }
 
 func GetRemoteMountDetails(s ssh.Interface, ip net.IP, target string) (bool, *Info) {


### PR DESCRIPTION
Signed-off-by: tgfree <tgfree7@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Umount the tmp overlay device by device path not mountpoint.

In the sealer (<=v0.8.6), sealer prune will prune build-tmp-data by umount and remove, but umount overlay type monuntpoint will failed. maybe we should just umount the device name not mountpoint.

I find out, in the master branch, the command `prune` has dropped. should i fix in the 0.8.6?

### Does this pull request fix one issue?
try to fix #1697
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
