### PR TITLE
fix: remove exit status 1 and display stderr info

### DIFF
--- a/pkg/runtime/kubernetes/init.go
+++ b/pkg/runtime/kubernetes/init.go
@@ -247,10 +247,6 @@ func (k *Runtime) InitMaster0() error {
 	// TODO skip docker version error check for test
 	output, err := client.Cmd(k.cluster.GetMaster0IP(), cmdInit)
 	if err != nil {
-		_, wErr := common.StdOut.WriteString(string(output))
-		if wErr != nil {
-			return err
-		}
 		return fmt.Errorf("failed to init master0: %s. Please clean and reinstall", err)
 	}
 	k.decodeMaster0Output(output)
@@ -298,7 +294,7 @@ func (k *Runtime) init() error {
 
 	for _, f := range pipeline {
 		if err := f(); err != nil {
-			return fmt.Errorf("failed to init master0: %v", err)
+			return fmt.Errorf("failed to init cluster: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
When sealer binary runs into an error, it is quite important for sealer to throw out the detailed and explicit error message. While I found that in lots of cases, sealer binary always throws an error message containing `exit status 1`, which seems to meaningless and helpless for any end-user. Here is an issue list which reflect the situation above:
* https://github.com/sealerio/sealer/issues/1618
* https://github.com/sealerio/sealer/issues/1580 
* https://github.com/sealerio/sealer/issues/1519
* https://github.com/sealerio/sealer/issues/1437
* and so on

This pull request changes such situation with outputting the stderr information. If we call some shell scripts, generally the error message would be always thrown into the os.Stderr. And if end-user could see the os.Stderr details, there is much more possibility for end-user to be noticed what detailed error happened there.

Since sealer replies on https://github.com/sealerio/basefs mostly, the shell scripts in basefs repo should be organized much more carefully, especially to throw out error message into stderr rather than throwing error message into stdout casually. @Stevent-fei @kakaZhou719 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
none

### Describe how to verify it
none

### Special notes for reviews
I just modified `func (s *SSH) Cmd(host net.IP, cmd string)` and `unc (s *SSH) CmdToString(host net.IP, cmd, split string)`, and have not modified `func (s *SSH) CmdAsync(host net.IP, cmds ...string)`. 

I wish to see the initial effect of this pull request, and move it on CmdAsync by the result.