### PR TITLE
optimize the buildah options

### DIFF
--- a/apply/driver/local.go
+++ b/apply/driver/local.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/sealerio/sealer/apply/processor"
 	"github.com/sealerio/sealer/common"
-	"github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/client/k8s"
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	imagecommon "github.com/sealerio/sealer/pkg/define/options"
@@ -111,7 +110,6 @@ func (applier *Applier) mountClusterImage() error {
 	// TODO optimize image engine caller.
 	for _, plat := range plats {
 		err = applier.ImageEngine.Pull(&imagecommon.PullOptions{
-			Authfile:   auth.GetDefaultAuthFilePath(),
 			Quiet:      false,
 			TLSVerify:  true,
 			PullPolicy: "missing",

--- a/apply/processor/create.go
+++ b/apply/processor/create.go
@@ -19,7 +19,6 @@ import (
 
 	imagecommon "github.com/sealerio/sealer/pkg/define/options"
 
-	"github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/sealerio/sealer/pkg/registry"
 
@@ -96,7 +95,6 @@ func (c *CreateProcessor) MountImage(cluster *v2.Cluster) error {
 	}
 	for _, plat := range plats {
 		if err = c.ImageEngine.Pull(&imagecommon.PullOptions{
-			Authfile:   auth.GetDefaultAuthFilePath(),
 			Quiet:      false,
 			TLSVerify:  true,
 			PullPolicy: "missing",

--- a/apply/processor/gen.go
+++ b/apply/processor/gen.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 
 	"github.com/sealerio/sealer/common"
-	"github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/client/k8s"
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	"github.com/sealerio/sealer/pkg/define/options"
@@ -176,7 +175,6 @@ func (g *GenerateProcessor) MountImage(cluster *v2.Cluster) error {
 	image := cluster.Spec.Image
 	for _, p := range platforms {
 		if err := g.ImageEngine.Pull(&options.PullOptions{
-			Authfile:   auth.GetDefaultAuthFilePath(),
 			TLSVerify:  true,
 			PullPolicy: "missing",
 			Image:      image,

--- a/cmd/sealer/cmd/image/build.go
+++ b/cmd/sealer/cmd/image/build.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containers/buildah/pkg/parse"
 	"github.com/pkg/errors"
 	"github.com/sealerio/sealer/build/buildimage"
-	pkgauth "github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	"github.com/sealerio/sealer/version"
@@ -73,14 +72,15 @@ func NewBuildCmd() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Example: exampleNewBuildCmd,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			buildFlags.ContextDir = args[0]
+			if len(args) > 0 {
+				buildFlags.ContextDir = args[0]
+			}
 			return buildSealerImage()
 		},
 	}
 	buildCmd.Flags().StringVarP(&buildFlags.Kubefile, "file", "f", "Kubefile", "Kubefile filepath")
 	buildCmd.Flags().StringVar(&buildFlags.Platform, "platform", parse.DefaultPlatform(), "set the target platform, like linux/amd64 or linux/amd64/v7")
 	buildCmd.Flags().StringVar(&buildFlags.PullPolicy, "pull", "", "pull policy. Allow for --pull, --pull=true, --pull=false, --pull=never, --pull=always")
-	buildCmd.Flags().StringVar(&buildFlags.Authfile, "authfile", pkgauth.GetDefaultAuthFilePath(), "path of the authentication file.")
 	buildCmd.Flags().BoolVar(&buildFlags.NoCache, "no-cache", false, "do not use existing cached images for building. Build from the start with a new set of cached layers.")
 	buildCmd.Flags().BoolVar(&buildFlags.Base, "base", true, "build with base image, default value is true.")
 	buildCmd.Flags().StringSliceVarP(&buildFlags.Tags, "tag", "t", []string{}, "specify a name for ClusterImage")

--- a/cmd/sealer/cmd/image/login.go
+++ b/cmd/sealer/cmd/image/login.go
@@ -17,7 +17,6 @@ package image
 import (
 	"os"
 
-	"github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/sirupsen/logrus"
@@ -47,7 +46,6 @@ func NewLoginCmd() *cobra.Command {
 	loginConfig = &options.LoginOptions{}
 	loginCmd.Flags().StringVarP(&loginConfig.Username, "username", "u", "", "user name for login registry")
 	loginCmd.Flags().StringVarP(&loginConfig.Password, "passwd", "p", "", "password for login registry")
-	loginCmd.Flags().StringVar(&loginConfig.AuthFile, "authfile", auth.GetDefaultAuthFilePath(), "path to store auth file after login. It will be $HOME/.sealer/auth.json by default.")
 	loginCmd.Flags().BoolVar(&loginConfig.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	if err := loginCmd.MarkFlagRequired("username"); err != nil {
 		logrus.Errorf("failed to init flag: %v", err)

--- a/cmd/sealer/cmd/image/logout.go
+++ b/cmd/sealer/cmd/image/logout.go
@@ -15,7 +15,6 @@
 package image
 
 import (
-	"github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/spf13/cobra"
@@ -42,6 +41,5 @@ func NewLogoutCmd() *cobra.Command {
 		},
 	}
 	logoutConfig = &options.LogoutOptions{}
-	logoutCmd.Flags().StringVar(&logoutConfig.Authfile, "authfile", auth.GetDefaultAuthFilePath(), "path to store auth file after login. It will be $HOME/.sealer/auth.json by default.")
 	return logoutCmd
 }

--- a/cmd/sealer/cmd/image/pull.go
+++ b/cmd/sealer/cmd/image/pull.go
@@ -16,7 +16,6 @@ package image
 
 import (
 	"github.com/containers/buildah/pkg/parse"
-	pkgauth "github.com/sealerio/sealer/pkg/auth"
 	"github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/spf13/cobra"
@@ -46,7 +45,6 @@ func NewPullCmd() *cobra.Command {
 	}
 	pullOpts = &options.PullOptions{}
 	pullCmd.Flags().StringVar(&pullOpts.Platform, "platform", parse.DefaultPlatform(), "prefer OS/ARCH instead of the current operating system and architecture for choosing images")
-	pullCmd.Flags().StringVar(&pullOpts.Authfile, "authfile", pkgauth.GetDefaultAuthFilePath(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	pullCmd.Flags().BoolVar(&pullOpts.TLSVerify, "tls-verify", true, "require HTTPS and verify certificates when accessing the registry. TLS verification cannot be used when talking to an insecure registry.")
 	pullCmd.Flags().StringVar(&pullOpts.PullPolicy, "policy", "missing", "missing, always, or never.")
 	pullCmd.Flags().BoolVarP(&pullOpts.Quiet, "quiet", "q", false, "don't output progress information when pulling images")

--- a/pkg/define/options/options.go
+++ b/pkg/define/options/options.go
@@ -23,7 +23,6 @@ type BuildOptions struct {
 	BuildArgs   []string
 	Platform    string
 	ContextDir  string
-	Authfile    string
 	PullPolicy  string
 	Labels      []string
 	Annotations []string
@@ -72,14 +71,11 @@ type LoginOptions struct {
 	Username  string
 	Password  string
 	TLSVerify bool
-	CertDir   string
-	AuthFile  string
 }
 
 type LogoutOptions struct {
-	Authfile string
-	All      bool
-	Domain   string
+	All    bool
+	Domain string
 }
 
 type PushOptions struct {
@@ -94,7 +90,6 @@ type PushOptions struct {
 }
 
 type PullOptions struct {
-	Authfile   string
 	CertDir    string
 	Quiet      bool
 	TLSVerify  bool

--- a/pkg/imageengine/buildah/commit.go
+++ b/pkg/imageengine/buildah/commit.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/buildah/util"
 	"github.com/containers/image/v5/pkg/shortnames"
 	storageTransport "github.com/containers/image/v5/storage"
@@ -60,16 +59,13 @@ func (engine *Engine) Commit(opts *options.CommitOptions) error {
 		return errors.Wrapf(err, "error reading build container %q", name)
 	}
 
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return errors.Wrapf(err, "error building system context")
-	}
+	systemCxt := engine.SystemContext()
 
 	// If the user specified an image, we may need to massage it a bit if
 	// no transport is specified.
 	// TODO we support commit to local image only, we'd better limit the input of name
 	if dest, err = alltransports.ParseImageName(image); err != nil {
-		candidates, err := shortnames.ResolveLocally(systemContext, image)
+		candidates, err := shortnames.ResolveLocally(systemCxt, image)
 		if err != nil {
 			return err
 		}
@@ -87,7 +83,7 @@ func (engine *Engine) Commit(opts *options.CommitOptions) error {
 		PreferredManifestType: format,
 		Manifest:              opts.Manifest,
 		Compression:           compress,
-		SystemContext:         systemContext,
+		SystemContext:         systemCxt,
 		Squash:                opts.Squash,
 	}
 	if opts.Timestamp != 0 {

--- a/pkg/imageengine/buildah/from.go
+++ b/pkg/imageengine/buildah/from.go
@@ -53,10 +53,7 @@ func (engine *Engine) createContainerFromImage(opts *options.FromOptions) (strin
 	}
 
 	// TODO be aware of this, maybe this will incur platform problem.
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return "", errors.Wrapf(err, "error building system context")
-	}
+	systemCxt := engine.SystemContext()
 
 	// TODO we do not support from remote currently
 	// which is to make the policy pull-if-missing
@@ -100,7 +97,7 @@ func (engine *Engine) createContainerFromImage(opts *options.FromOptions) (strin
 		Container:             "",
 		ContainerSuffix:       "",
 		PullPolicy:            pullPolicy,
-		SystemContext:         systemContext,
+		SystemContext:         systemCxt,
 		DefaultMountsFilePath: "",
 		Isolation:             isolation,
 		NamespaceOptions:      namespaceOptions,

--- a/pkg/imageengine/buildah/get_annotation.go
+++ b/pkg/imageengine/buildah/get_annotation.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sealerio/sealer/pkg/define/options"
 
 	"github.com/containers/buildah"
-	"github.com/containers/buildah/pkg/parse"
 )
 
 func (engine *Engine) GetImageAnnotation(opts *options.GetImageAnnoOptions) (map[string]string, error) {
@@ -28,17 +27,11 @@ func (engine *Engine) GetImageAnnotation(opts *options.GetImageAnnoOptions) (map
 		return nil, errors.New("image name id or image name should be specified")
 	}
 
-	var builder *buildah.Builder
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return nil, err
-	}
-
 	ctx := getContext()
 	store := engine.ImageStore()
 	name := opts.ImageNameOrID
 
-	builder, err = openImage(ctx, systemContext, store, name)
+	builder, err := openImage(ctx, engine.SystemContext(), store, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imageengine/buildah/images.go
+++ b/pkg/imageengine/buildah/images.go
@@ -15,7 +15,6 @@
 package buildah
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -25,10 +24,8 @@ import (
 	"github.com/sealerio/sealer/pkg/define/options"
 
 	"github.com/containers/buildah/pkg/formats"
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/libimage"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 const none = "<none>"
@@ -81,18 +78,7 @@ var imagesHeader = map[string]string{
 }
 
 func (engine *Engine) Images(opts *options.ImagesOptions) error {
-	store := engine.ImageStore()
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return errors.Wrapf(err, "error building system context")
-	}
-	runtime, err := libimage.RuntimeFromStore(store, &libimage.RuntimeOptions{SystemContext: systemContext})
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-
+	runtime := engine.libimageRuntime
 	options := &libimage.ListImagesOptions{}
 	if !opts.All {
 		options.Filters = append(options.Filters, "intermediate=false")
@@ -100,7 +86,7 @@ func (engine *Engine) Images(opts *options.ImagesOptions) error {
 	}
 
 	//TODO add some label to identify sealer image and oci image.
-	images, err := runtime.ListImages(ctx, []string{}, options)
+	images, err := runtime.ListImages(getContext(), []string{}, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/imageengine/buildah/inspect.go
+++ b/pkg/imageengine/buildah/inspect.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sealerio/sealer/pkg/define/options"
 
 	"github.com/containers/buildah"
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/pkg/errors"
 	"golang.org/x/term"
 
@@ -40,12 +39,10 @@ func (engine *Engine) Inspect(opts *options.InspectOptions) error {
 	if len(opts.ImageNameOrID) == 0 {
 		return errors.Errorf("image name or image id must be specified.")
 	}
-	var builder *buildah.Builder
-
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return err
-	}
+	var (
+		builder *buildah.Builder
+		err     error
+	)
 
 	ctx := getContext()
 	store := engine.ImageStore()
@@ -53,7 +50,7 @@ func (engine *Engine) Inspect(opts *options.InspectOptions) error {
 
 	switch opts.InspectType {
 	case inspectTypeImage:
-		builder, err = openImage(ctx, systemContext, store, name)
+		builder, err = openImage(ctx, engine.SystemContext(), store, name)
 		if err != nil {
 			return err
 		}

--- a/pkg/imageengine/buildah/login.go
+++ b/pkg/imageengine/buildah/login.go
@@ -17,7 +17,6 @@ package buildah
 import (
 	"context"
 
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
 	"github.com/sealerio/sealer/pkg/define/options"
 
@@ -31,18 +30,12 @@ func (engine *Engine) Login(opts *options.LoginOptions) error {
 		return errors.Errorf("please specify a registry to login to")
 	}
 
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return errors.Wrapf(err, "error building system context")
-	}
-
-	systemContext.AuthFilePath = opts.AuthFile
+	systemCxt := engine.SystemContext()
 
 	return auth.Login(context.TODO(),
-		systemContext,
+		systemCxt,
 		&auth.LoginOptions{
-			AuthFile:           opts.AuthFile,
-			CertDir:            opts.CertDir,
+			AuthFile:           systemCxt.AuthFilePath,
 			Password:           opts.Password,
 			Username:           opts.Username,
 			Stdout:             os.Stdout,

--- a/pkg/imageengine/buildah/logout.go
+++ b/pkg/imageengine/buildah/logout.go
@@ -15,14 +15,12 @@
 package buildah
 
 import (
-	"github.com/containers/buildah/pkg/parse"
 	"github.com/containers/common/pkg/auth"
 	"github.com/sealerio/sealer/pkg/define/options"
 
 	"os"
 
 	"github.com/pkg/errors"
-	pkgauth "github.com/sealerio/sealer/pkg/auth"
 )
 
 func (engine *Engine) Logout(opts *options.LogoutOptions) error {
@@ -30,12 +28,9 @@ func (engine *Engine) Logout(opts *options.LogoutOptions) error {
 		return errors.Errorf("registry must be given")
 	}
 
-	systemContext, err := parse.SystemContextFromOptions(engine.Command)
-	if err != nil {
-		return errors.Wrapf(err, "error building system context")
-	}
-	return auth.Logout(systemContext, &auth.LogoutOptions{
-		AuthFile:           pkgauth.GetDefaultAuthFilePath(),
+	systemCxt := engine.SystemContext()
+	return auth.Logout(systemCxt, &auth.LogoutOptions{
+		AuthFile:           systemCxt.AuthFilePath,
 		All:                opts.All,
 		AcceptRepositories: true,
 		Stdout:             os.Stdout,


### PR DESCRIPTION
There are general options for cmds could be put into the engine. Instead of initialize one for every command.
And this could help to fix redefine problem.
@VinceCui @kakaZhou719 FYI.