### PR TITLE
Fix: image mount panic

### DIFF
--- a/utils/mount/mount_service.go
+++ b/utils/mount/mount_service.go
@@ -154,7 +154,7 @@ type Info struct {
 
 func GetMountDetails(target string) (bool, *Info) {
 	infos, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(target))
-	if err != nil {
+	if err != nil || len(infos) == 0 {
 		return false, nil
 	}
 	return mountCmdResultSplit(infos[0].VFSOptions, target)


### PR DESCRIPTION
Signed-off-by: tgfree <tgfree7@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

When mountinfo.GetMounts return an empty []*info, caused a panic.
### Does this pull request fix one issue?
#1717 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
