### PR TITLE
fix ci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ run:
 
   modules-download-mode: vendor
 
+  build-tags:
+    - containers_image_openpgp
+
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint


### PR DESCRIPTION
<img width="1216" alt="Screen Shot 2022-09-26 at 12 42 24" src="https://user-images.githubusercontent.com/38838049/192195513-04b358ce-cc24-4d35-8386-cdc50ebeb8ab.png">

Due to the library "gpgme" can't not be included well in apple silicon(m1), it will be problem when do golangci-lint.