### PR TITLE
fix k0s reset bug.

### DIFF
--- a/pkg/runtime/k0s/delete_masters.go
+++ b/pkg/runtime/k0s/delete_masters.go
@@ -61,7 +61,7 @@ func (k *Runtime) deleteMaster(master net.IP) error {
 	STEP7: delete node though k8s client
 	*/
 	remoteCleanCmd := []string{"k0s stop",
-		fmt.Sprintf("k0s reset --config %s --cri-socket %s", DefaultK0sConfigPath, ExternalCRI),
+		fmt.Sprintf("k0s reset --cri-socket %s", ExternalCRI),
 		"rm -rf /etc/k0s/",
 		fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts", SeaHub),
 		fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts", k.RegConfig.Domain),

--- a/pkg/runtime/k0s/delete_nodes.go
+++ b/pkg/runtime/k0s/delete_nodes.go
@@ -60,7 +60,7 @@ func (k *Runtime) deleteNode(node net.IP) error {
 	STEP7: delete node though k8s client
 	*/
 	remoteCleanCmds := []string{"k0s stop",
-		fmt.Sprintf("k0s reset --config %s --cri-socket %s", DefaultK0sConfigPath, ExternalCRI),
+		fmt.Sprintf("k0s reset --cri-socket %s", ExternalCRI),
 		"rm -rf /etc/k0s/",
 		fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts", SeaHub),
 		fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts", k.RegConfig.Domain),

--- a/pkg/runtime/k0s/init.go
+++ b/pkg/runtime/k0s/init.go
@@ -105,7 +105,7 @@ func (k *Runtime) BootstrapMaster0() error {
 	if err != nil {
 		return err
 	}
-	bootstrapCMD := fmt.Sprintf("k0s install controller -c %s", DefaultK0sConfigPath)
+	bootstrapCMD := fmt.Sprintf("k0s install controller -c %s --cri-socket %s", DefaultK0sConfigPath, ExternalCRI)
 	if _, err := ssh.Cmd(master0IP, bootstrapCMD); err != nil {
 		return err
 	}

--- a/pkg/runtime/k0s/join_masters.go
+++ b/pkg/runtime/k0s/join_masters.go
@@ -47,7 +47,7 @@ func (k *Runtime) joinMasters(masters []net.IP) error {
 	if err := k.CopyJoinToken(ControllerRole, masters); err != nil {
 		return err
 	}
-	cmds := k.Command(ControllerRole)
+	cmds := k.JoinCommand(ControllerRole)
 	if cmds == nil {
 		return fmt.Errorf("failed to get join master command")
 	}

--- a/pkg/runtime/k0s/join_nodes.go
+++ b/pkg/runtime/k0s/join_nodes.go
@@ -52,7 +52,7 @@ func (k *Runtime) joinNodes(nodes []net.IP) error {
 	if k.RegConfig.Username != "" && k.RegConfig.Password != "" {
 		addRegistryHostsAndLogin = fmt.Sprintf("%s && %s", addRegistryHostsAndLogin, k.GenLoginCommand())
 	}
-	cmds := k.Command(WorkerRole)
+	cmds := k.JoinCommand(WorkerRole)
 	if cmds == nil {
 		return fmt.Errorf("failed to get join node command")
 	}

--- a/pkg/runtime/k0s/reset.go
+++ b/pkg/runtime/k0s/reset.go
@@ -66,14 +66,15 @@ func (k *Runtime) resetNode(node net.IP) error {
 	if err != nil {
 		return err
 	}
-	/** To reset a node, do following command one by one:
+
+	/** To reset a node, do following commands one by one:
 	STEP1: stop k0s service
 	STEP2: reset the node with install configuration
 	STEP3: remove k0s cluster config generate by k0s under /etc/k0s
 	STEP4: remove private registry config in /etc/host
 	*/
 	if err := ssh.CmdAsync(node, "k0s stop",
-		fmt.Sprintf("k0s reset --config %s --cri-socket %s", DefaultK0sConfigPath, ExternalCRI),
+		fmt.Sprintf("k0s reset --cri-socket %s", ExternalCRI),
 		"rm -rf /etc/k0s/",
 		"rm -rf /usr/bin/kube* && rm -rf ~/.kube/",
 		fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts", SeaHub),

--- a/pkg/runtime/k0s/runtime.go
+++ b/pkg/runtime/k0s/runtime.go
@@ -219,12 +219,12 @@ func (k *Runtime) CopyJoinToken(role string, hosts []net.IP) error {
 	return nil
 }
 
-func (k *Runtime) Command(role string) []string {
+func (k *Runtime) JoinCommand(role string) []string {
 	cmds := map[string][]string{
 		ControllerRole: {"mkdir -r /etc/k0s", fmt.Sprintf("k0s config create > %s", DefaultK0sConfigPath),
 			fmt.Sprintf("sed -i '/  images/ a\\    repository: \"%s:%s\"' %s", k.RegConfig.Domain, k.RegConfig.Port, DefaultK0sConfigPath),
-			fmt.Sprintf("k0s install controller --token-file %s -c %s",
-				DefaultK0sControllerJoin, DefaultK0sConfigPath),
+			fmt.Sprintf("k0s install controller --token-file %s -c %s --cri-socket %s",
+				DefaultK0sControllerJoin, DefaultK0sConfigPath, ExternalCRI),
 			"k0s start",
 		},
 		WorkerRole: {fmt.Sprintf("k0s install worker --cri-socket %s --token-file %s", ExternalCRI, DefaultK0sWorkerJoin),
@@ -233,7 +233,6 @@ func (k *Runtime) Command(role string) []string {
 
 	v, ok := cmds[role]
 	if !ok {
-		logrus.Errorf("failed to get k0s command: %v", cmds)
 		return nil
 	}
 	return v


### PR DESCRIPTION
Signed-off-by: starComingup <1225067236@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
k0s nodes reset do not need to specify `--config`  so this made sealer delete failed. In this PR, resolve this bug.
And master nodes will set default config path:`/etc/k0s/k0s.yaml/` which same as our config path,

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->