### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/build/layerutils/manifests/manifests.go
+++ b/build/layerutils/manifests/manifests.go
@@ -16,7 +16,7 @@ package manifest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/build/layerutils"
@@ -28,7 +28,7 @@ type Manifests struct{}
 func (manifests *Manifests) ListImages(yamlFile string) ([]string, error) {
 	var list []string
 
-	yamlBytes, err := ioutil.ReadFile(filepath.Clean(yamlFile))
+	yamlBytes, err := os.ReadFile(filepath.Clean(yamlFile))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %s", err)
 	}

--- a/pkg/client/docker/auth/auth.go
+++ b/pkg/client/docker/auth/auth.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -79,7 +78,7 @@ func (s *DockerAuthService) SetAuthInfo(hostname, username, password string) err
 		return err
 	}
 
-	if err := ioutil.WriteFile(s.FilePath, data, common.FileMode0644); err != nil {
+	if err := os.WriteFile(s.FilePath, data, common.FileMode0644); err != nil {
 		return fmt.Errorf("write %s failed,%s", s.FilePath, err)
 	}
 	return nil
@@ -115,7 +114,7 @@ func NewDockerAuthService() (DockerAuthService, error) {
 		return das, nil
 	}
 
-	content, err := ioutil.ReadFile(filepath.Clean(authFile))
+	content, err := os.ReadFile(filepath.Clean(authFile))
 	if err != nil {
 		return das, err
 	}

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -17,7 +17,7 @@ package clusterfile
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/pkg/runtime/kubernetes/kubeadm"
@@ -62,7 +62,7 @@ func NewClusterFile(path string) (Interface, error) {
 		return clusterFile, nil
 	}
 
-	clusterFileData, err := ioutil.ReadFile(filepath.Clean(path))
+	clusterFileData, err := os.ReadFile(filepath.Clean(path))
 
 	if err != nil {
 		return nil, err

--- a/pkg/clusterfile/util.go
+++ b/pkg/clusterfile/util.go
@@ -16,7 +16,6 @@ package clusterfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,7 +31,7 @@ import (
 var ErrClusterNotExist = fmt.Errorf("no cluster exist")
 
 func GetDefaultClusterName() (string, error) {
-	files, err := ioutil.ReadDir(fmt.Sprintf("%s/.sealer", common.GetHomeDir()))
+	files, err := os.ReadDir(fmt.Sprintf("%s/.sealer", common.GetHomeDir()))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	stdos "os"
 	"path/filepath"
 	"strings"
 
@@ -77,7 +77,7 @@ func (c *Dumper) WriteFiles(configs []v1.Config) error {
 			}
 		}
 
-		contents, err := ioutil.ReadFile(filepath.Clean(configPath))
+		contents, err := stdos.ReadFile(filepath.Clean(configPath))
 		if err != nil {
 			return err
 		}

--- a/pkg/filesystem/cloudfilesystem/utils.go
+++ b/pkg/filesystem/cloudfilesystem/utils.go
@@ -16,8 +16,8 @@ package cloudfilesystem
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/utils/os/fs"
@@ -30,7 +30,7 @@ import (
 )
 
 func copyFiles(sshEntry ssh.Interface, ip net.IP, src, target string) error {
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	if err != nil {
 		return fmt.Errorf("failed to copy files: %s", err)
 	}

--- a/pkg/filesystem/clusterimage/clusterimage.go
+++ b/pkg/filesystem/clusterimage/clusterimage.go
@@ -16,7 +16,6 @@ package clusterimage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -61,7 +60,7 @@ func (m *mounter) umountImage(cluster *v2.Cluster) error {
 	if !osi.IsFileExist(mountRootDir) {
 		return nil
 	}
-	dir, err := ioutil.ReadDir(mountRootDir)
+	dir, err := os.ReadDir(mountRootDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/image/save/filesystem.go
+++ b/pkg/image/save/filesystem.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -138,7 +137,7 @@ func (d *driver) GetContent(ctx context.Context, path string) ([]byte, error) {
 	}
 	defer rc.Close()
 
-	p, err := ioutil.ReadAll(rc)
+	p, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imageengine/buildah/build.go
+++ b/pkg/imageengine/buildah/build.go
@@ -16,17 +16,14 @@ package buildah
 
 import (
 	"context"
-
 	"fmt"
-
-	"github.com/sealerio/sealer/pkg/define/options"
-
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/sealerio/sealer/pkg/define/options"
 
 	"github.com/containers/buildah/define"
 	"github.com/containers/buildah/imagebuildah"
@@ -294,7 +291,7 @@ func (engine *Engine) wrapper2Options(opts *options.BuildOptions, wrapper *build
 	}
 
 	if wrapper.Quiet {
-		options.ReportWriter = ioutil.Discard
+		options.ReportWriter = io.Discard
 	}
 
 	return options, kubefiles, nil

--- a/pkg/imageengine/buildah/from.go
+++ b/pkg/imageengine/buildah/from.go
@@ -16,13 +16,11 @@ package buildah
 
 import (
 	"fmt"
-
-	"github.com/sealerio/sealer/pkg/define/options"
-
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/sealerio/sealer/pkg/define/options"
 
 	"github.com/containers/buildah"
 	"github.com/containers/buildah/define"
@@ -243,7 +241,7 @@ func onBuild(builder *buildah.Builder, quiet bool) error {
 		case "RUN":
 			var stdout io.Writer
 			if quiet {
-				stdout = ioutil.Discard
+				stdout = io.Discard
 			}
 			if err := builder.Run(args, buildah.RunOptions{Stdout: stdout}); err != nil {
 				return err

--- a/pkg/plugin/etcd_backup_plugin.go
+++ b/pkg/plugin/etcd_backup_plugin.go
@@ -20,8 +20,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -96,7 +96,7 @@ func connEtcd(masterIP net.IP) (clientv3.Config, error) {
 		return clientv3.Config{}, fmt.Errorf("failed to load cacert or key file: %v", err)
 	}
 
-	caData, err := ioutil.ReadFile(etcdCa)
+	caData, err := os.ReadFile(etcdCa)
 	if err != nil {
 		return clientv3.Config{}, fmt.Errorf("failed to read ca certificate: %v", err)
 	}

--- a/pkg/plugin/plugins.go
+++ b/pkg/plugin/plugins.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func (c *PluginsProcessor) Load() error {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return fmt.Errorf("failed to load plugin dir: %v", err)
 	}

--- a/pkg/plugin/test/label_nodes.go
+++ b/pkg/plugin/test/label_nodes.go
@@ -111,9 +111,9 @@ func (l LabelsNodes) getAddress(addresses []v1.NodeAddress) string {
 }
 
 // Plugin is the exposed variable sealer will look up it.
-//nolint
+// nolint
 var Plugin LabelsNodes
 
 // PluginType is the exposed variable defined the type of this plugin.
-//nolint
+// nolint
 var PluginType = "LABEL_TEST_SO"

--- a/pkg/runtime/kubernetes/kubeadm/kubeadm_config_test.go
+++ b/pkg/runtime/kubernetes/kubeadm/kubeadm_config_test.go
@@ -16,7 +16,6 @@ package kubeadm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -350,7 +349,7 @@ func TestKubeadmConfig_LoadFromClusterfile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			k := tt.fields.KubeConfig
 			testfile := "test-Clusterfile"
-			err := ioutil.WriteFile(testfile, tt.args.kubeadmconfig, 0644)
+			err := os.WriteFile(testfile, tt.args.kubeadmconfig, 0644)
 			if err != nil {
 				t.Errorf("WriteFile %s error = %v, wantErr %v", testfile, err, tt.wantErr)
 			}
@@ -410,7 +409,7 @@ func TestKubeadmConfig_Merge(t *testing.T) {
 							return
 						}*/
 			testfile := "test-kubeadm.yml"
-			err := ioutil.WriteFile(testfile, tt.args.defaultKubeadmConfig, 0644)
+			err := os.WriteFile(testfile, tt.args.defaultKubeadmConfig, 0644)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("WriteFile %s error = %v, wantErr %v", testfile, err, tt.wantErr)
 				return

--- a/pkg/runtime/utils.go
+++ b/pkg/runtime/utils.go
@@ -17,8 +17,8 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -37,7 +37,7 @@ func LoadMetadata(rootfs string) (*Metadata, error) {
 		return nil, nil
 	}
 
-	metadataFile, err = ioutil.ReadFile(filepath.Clean(metadataPath))
+	metadataFile, err = os.ReadFile(filepath.Clean(metadataPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read ClusterImage metadata: %v", err)
 	}

--- a/pkg/runtime/utils_test.go
+++ b/pkg/runtime/utils_test.go
@@ -15,7 +15,6 @@
 package runtime
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -87,7 +86,7 @@ func TestLoadMetadata(t *testing.T) {
 				t.Errorf("Make dir %s error = %s, wantErr %v", dir, err, tt.wantErr)
 			}
 
-			err = ioutil.WriteFile(filepath.Join(dir, rootfsPath, metadataFileName), tt.object.RuntimeMetadata, 0777)
+			err = os.WriteFile(filepath.Join(dir, rootfsPath, metadataFileName), tt.object.RuntimeMetadata, 0777)
 			if err != nil {
 				t.Errorf("Write file %s error = %v, wantErr %v", filepath.Join(dir, rootfsPath, metadataFileName), err, tt.wantErr)
 			}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,7 +53,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		"color": true
 	},
 	"TimeFormat":"2006-01-02 15:04:05"}`
-	err = ioutil.WriteFile(filepath.Join(home, ".sealer.json"), []byte(logcfg), os.ModePerm)
+	err = os.WriteFile(filepath.Join(home, ".sealer.json"), []byte(logcfg), os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
 	return nil
 }, func(data []byte) {

--- a/test/suites/build/build.go
+++ b/test/suites/build/build.go
@@ -17,7 +17,6 @@ package build
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -91,9 +90,9 @@ func CheckIsImageExist(imageName string) bool {
 }
 
 func UpdateKubeFromImage(imageName string, KubefilePath string) {
-	Kube, err := ioutil.ReadFile(filepath.Clean(KubefilePath))
+	Kube, err := os.ReadFile(filepath.Clean(KubefilePath))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	Kube = append([]byte(fmt.Sprintf("FROM %s", imageName)), Kube[bytes.IndexByte(Kube, '\n'):]...) // #nosec
-	err = ioutil.WriteFile(KubefilePath, Kube, os.ModePerm)
+	err = os.WriteFile(KubefilePath, Kube, os.ModePerm)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/test/testhelper/utils.go
+++ b/test/testhelper/utils.go
@@ -16,7 +16,6 @@ package testhelper
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func GetPwd() string {
 
 func CreateTempFile() string {
 	dir := os.TempDir()
-	file, err := ioutil.TempFile(dir, "tmpfile")
+	file, err := os.CreateTemp(dir, "tmpfile")
 	CheckErr(err)
 	defer CheckErr(file.Close())
 	return file.Name()
@@ -62,7 +61,7 @@ func WriteFile(fileName string, content []byte) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(fileName, content, settings.FileMode0644); err != nil {
+	if err := os.WriteFile(fileName, content, settings.FileMode0644); err != nil {
 		return err
 	}
 	return nil
@@ -124,7 +123,7 @@ func IsFileExist(filename string) bool {
 }
 
 func UnmarshalYamlFile(file string, obj interface{}) error {
-	data, err := ioutil.ReadFile(filepath.Clean(file))
+	data, err := os.ReadFile(filepath.Clean(file))
 	if err != nil {
 		return err
 	}

--- a/utils/archive/compress_test.go
+++ b/utils/archive/compress_test.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint
+// nolint
 package archive
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -120,7 +119,7 @@ func TestTarWithRootDir(t *testing.T) {
 		t.Error(err)
 	}
 
-	tmp, err := ioutil.TempFile("/tmp", "tar")
+	tmp, err := os.CreateTemp("/tmp", "tar")
 	_, err = io.Copy(tmp, reader)
 	if err != nil {
 		t.Error(err)

--- a/utils/mount/default.go
+++ b/utils/mount/default.go
@@ -17,7 +17,6 @@ package mount
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -90,7 +89,7 @@ func copyDir(srcPath string, dstPath string) error {
 		}
 	}
 
-	srcFiles, err := ioutil.ReadDir(srcPath)
+	srcFiles, err := os.ReadDir(srcPath)
 	if err != nil {
 		return err
 	}

--- a/utils/os/fs.go
+++ b/utils/os/fs.go
@@ -16,7 +16,6 @@ package os
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -81,7 +80,7 @@ type FilterOptions struct {
 
 // GetDirNameListInDir :Get all Dir Name or file name List In Dir
 func GetDirNameListInDir(dir string, opts FilterOptions) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/os/fs/filesystem.go
+++ b/utils/os/fs/filesystem.go
@@ -18,7 +18,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -64,7 +63,7 @@ func (f filesystem) MkdirAll(path string) error {
 }
 
 func (f filesystem) MkTmpdir() (string, error) {
-	tempDir, err := ioutil.TempDir(common.DefaultTmpDir, ".DTmp-")
+	tempDir, err := os.MkdirTemp(common.DefaultTmpDir, ".DTmp-")
 	if err != nil {
 		return "", err
 	}
@@ -77,7 +76,7 @@ func (f filesystem) CopyDir(srcPath, dstPath string) error {
 		return err
 	}
 
-	fis, err := ioutil.ReadDir(srcPath)
+	fis, err := os.ReadDir(srcPath)
 	if err != nil {
 		return err
 	}

--- a/utils/os/readers.go
+++ b/utils/os/readers.go
@@ -17,7 +17,6 @@ package os
 import (
 	"bufio"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -76,7 +75,7 @@ func (r fileReader) ReadAll() ([]byte, error) {
 		}
 	}()
 
-	content, err := ioutil.ReadFile(filepath.Clean(r.fileName))
+	content, err := os.ReadFile(filepath.Clean(r.fileName))
 	if err != nil {
 		return nil, err
 	}

--- a/utils/os/writers.go
+++ b/utils/os/writers.go
@@ -15,7 +15,6 @@
 package os
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -52,7 +51,7 @@ func (a *atomicFileWriter) close() (err error) {
 }
 
 func newAtomicFileWriter(path string, perm os.FileMode) (*atomicFileWriter, error) {
-	tmpFile, err := ioutil.TempFile(filepath.Dir(path), ".FTmp-")
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), ".FTmp-")
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ssh/connect.go
+++ b/utils/ssh/connect.go
@@ -17,8 +17,8 @@ package ssh
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -108,7 +108,7 @@ func (s *SSH) sshAuthMethod(password, pkFile, pkPasswd string) (auth []ssh.AuthM
 
 // Authentication with a private key,private key has password and no password to verify in this
 func (s *SSH) sshPrivateKeyMethod(pkFile, pkPassword string) (am ssh.AuthMethod, err error) {
-	pkData, err := ioutil.ReadFile(filepath.Clean(pkFile))
+	pkData, err := os.ReadFile(filepath.Clean(pkFile))
 	if err != nil {
 		return nil, err
 	}

--- a/utils/ssh/scp.go
+++ b/utils/ssh/scp.go
@@ -17,7 +17,6 @@ package ssh
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -203,7 +202,7 @@ func (s *SSH) remoteMd5Sum(host net.IP, remoteFilePath string) string {
 }
 
 func (s *SSH) copyLocalDirToRemote(host net.IP, sftpClient *sftp.Client, localPath, remotePath string, epu *easyProgressUtil) {
-	localFiles, err := ioutil.ReadDir(localPath)
+	localFiles, err := os.ReadDir(localPath)
 	if err != nil {
 		logrus.Errorf("failed to read local path dir(%s) on host(%s): %s", localPath, host, err)
 		return

--- a/utils/yaml/yaml.go
+++ b/utils/yaml/yaml.go
@@ -17,7 +17,7 @@ package yaml
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -28,7 +28,7 @@ import (
 )
 
 func UnmarshalFile(file string, obj interface{}) error {
-	data, err := ioutil.ReadFile(filepath.Clean(file))
+	data, err := os.ReadFile(filepath.Clean(file))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

### Does this pull request fix one issue?


### Describe how you did it

Replaces:
- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

### Describe how to verify it

This PR is a non-breaking change.

### Special notes for reviews
