### PR TITLE
optimize: load plugins before image distributor

### DIFF
--- a/cmd/sealer/cmd/cluster/join.go
+++ b/cmd/sealer/cmd/cluster/join.go
@@ -19,9 +19,6 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
 	"github.com/sealerio/sealer/cmd/sealer/cmd/utils"
 	"github.com/sealerio/sealer/common"
@@ -31,6 +28,8 @@ import (
 	"github.com/sealerio/sealer/pkg/imagedistributor"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/sealerio/sealer/pkg/infradriver"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 var joinFlags *types.Flags
@@ -129,11 +128,18 @@ func NewJoinCmd() *cobra.Command {
 				return err
 			}
 
+			plugins, err := loadPluginsFromImage(imageMountInfo)
+			if err != nil {
+				return err
+			}
+
+			if cf.GetPlugins() != nil {
+				plugins = append(plugins, cf.GetPlugins()...)
+			}
+
 			runtimeConfig := &clusterruntime.RuntimeConfig{
 				Distributor: distributor,
-			}
-			if cf.GetPlugins() != nil {
-				runtimeConfig.Plugins = cf.GetPlugins()
+				Plugins:     plugins,
 			}
 
 			if cf.GetKubeadmConfig() != nil {

--- a/pkg/cluster-runtime/installer.go
+++ b/pkg/cluster-runtime/installer.go
@@ -35,8 +35,6 @@ import (
 	v1 "github.com/sealerio/sealer/types/api/v1"
 )
 
-var ForceDelete bool
-
 // RuntimeConfig for Installer
 type RuntimeConfig struct {
 	ImageEngine            imageengine.Interface
@@ -71,14 +69,13 @@ func NewInstaller(infraDriver infradriver.InfraDriver, runtimeConfig RuntimeConf
 	}
 
 	// todo maybe we can support custom registry config later
-
-	clusterENV := infraDriver.GetClusterEnv()
-
 	var registryConfig = registry.Registry{
 		Domain: registry.DefaultDomain,
 		Port:   registry.DefaultPort,
 		Auth:   &registry.Auth{},
 	}
+
+	clusterENV := infraDriver.GetClusterEnv()
 	if domain := clusterENV["RegistryDomain"]; domain != nil {
 		registryConfig.Domain = domain.(string)
 	}

--- a/pkg/cluster-runtime/installer.go
+++ b/pkg/cluster-runtime/installer.go
@@ -99,12 +99,7 @@ func NewInstaller(infraDriver infradriver.InfraDriver, runtimeConfig RuntimeConf
 	}
 
 	// add installer hooks
-	plugins, err := LoadPluginsFromFile(filepath.Join(infraDriver.GetClusterRootfsPath(), "plugins"))
-	if err != nil {
-		return nil, err
-	}
-	plugins = append(plugins, runtimeConfig.Plugins...)
-	hooks, err := transferPluginsToHooks(plugins)
+	hooks, err := transferPluginsToHooks(runtimeConfig.Plugins)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster-runtime/scale.go
+++ b/pkg/cluster-runtime/scale.go
@@ -94,18 +94,6 @@ func (i *Installer) ScaleUp(newMasters, newWorkers []net.IP) (registry.Driver, r
 }
 
 func (i *Installer) ScaleDown(mastersToDelete, workersToDelete []net.IP) (registry.Driver, runtime.Driver, error) {
-	if len(workersToDelete) > 0 {
-		if err := confirmDeleteHosts(common.NODE, workersToDelete); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	if len(mastersToDelete) > 0 {
-		if err := confirmDeleteHosts(common.MASTER, mastersToDelete); err != nil {
-			return nil, nil, err
-		}
-	}
-
 	all := append(mastersToDelete, workersToDelete...)
 	// delete HostAlias
 	if err := i.infraDriver.DeleteClusterHostAliases(all); err != nil {

--- a/pkg/cluster-runtime/uninstall.go
+++ b/pkg/cluster-runtime/uninstall.go
@@ -15,8 +15,6 @@
 package clusterruntime
 
 import (
-	"fmt"
-
 	"github.com/sealerio/sealer/common"
 	containerruntime "github.com/sealerio/sealer/pkg/container-runtime"
 	"github.com/sealerio/sealer/pkg/registry"
@@ -28,11 +26,6 @@ func (i *Installer) UnInstall() error {
 	masters := i.infraDriver.GetHostIPListByRole(common.MASTER)
 	workers := getWorkerIPList(i.infraDriver)
 	all := append(masters, workers...)
-
-	if err := confirmDeleteHosts(fmt.Sprintf("%s/%s", common.MASTER, common.NODE), all); err != nil {
-		return err
-	}
-
 	// delete HostAlias
 	if err := i.infraDriver.DeleteClusterHostAliases(all); err != nil {
 		return err

--- a/pkg/cluster-runtime/utils.go
+++ b/pkg/cluster-runtime/utils.go
@@ -15,26 +15,11 @@
 package clusterruntime
 
 import (
-	"fmt"
 	"net"
 
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/infradriver"
-
-	"github.com/sealerio/sealer/utils"
 )
-
-func confirmDeleteHosts(role string, nodesToDelete []net.IP) error {
-	if !ForceDelete {
-		if pass, err := utils.ConfirmOperation(fmt.Sprintf("Are you sure to delete these %s: %v? ", role, nodesToDelete)); err != nil {
-			return err
-		} else if !pass {
-			return fmt.Errorf("exit the operation of delete these nodes")
-		}
-	}
-
-	return nil
-}
 
 func getWorkerIPList(infraDriver infradriver.InfraDriver) []net.IP {
 	masters := make(map[string]bool)

--- a/utils/platform/platform.go
+++ b/utils/platform/platform.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
 	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 )
@@ -119,29 +118,13 @@ func Parse(specifier string) (v1.Platform, error) {
 	return v1.Platform{}, errors.Wrapf(ErrInvalidArgument, "%q: cannot parse platform specifier", specifier)
 }
 
-func GetDefaultPlatform() *v1.Platform {
-	return &v1.Platform{
+func GetDefaultPlatform() v1.Platform {
+	return v1.Platform{
 		OS:           runtime.GOOS,
 		Architecture: runtime.GOARCH,
 		// The Variant field will be empty if arch != ARM.
 		Variant: cpuVariant(),
 	}
-}
-
-// GetPlatform : parse platform string,if is nil will return the default platform.
-func GetPlatform(v string) ([]*v1.Platform, error) {
-	var targetPlatforms []*v1.Platform
-
-	if v == "" {
-		targetPlatforms = []*v1.Platform{GetDefaultPlatform()}
-	} else {
-		tp, err := ParsePlatforms(v)
-		if err != nil {
-			return nil, err
-		}
-		targetPlatforms = tp
-	}
-	return targetPlatforms, nil
 }
 
 // Format returns a string specifier from the provided platform specification.
@@ -241,9 +224,8 @@ func normalizeOS(os string) string {
 	}
 	return os
 }
-
 func DefaultMountClusterImageDir(clusterName string) string {
-	return GetMountClusterImagePlatformDir(clusterName, *GetDefaultPlatform())
+	return GetMountClusterImagePlatformDir(clusterName, GetDefaultPlatform())
 }
 
 func GetMountClusterImagePlatformDir(clusterName string, platform v1.Platform) string {

--- a/utils/ssh/platform.go
+++ b/utils/ssh/platform.go
@@ -30,7 +30,7 @@ import (
 
 func (s *SSH) GetPlatform(host net.IP) (v1.Platform, error) {
 	if utilsnet.IsLocalIP(host, s.LocalAddress) {
-		return *platform.GetDefaultPlatform(), nil
+		return platform.GetDefaultPlatform(), nil
 	}
 
 	p := v1.Platform{}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. support load plugins from cluster image before image distributor.
2. save all mount info, like mount dir, platform, targethosts, after mount cluster image 
3. confirm first when sealer delete
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
