### PR TITLE
support sealer run-app sub command

### DIFF
--- a/cmd/sealer/cmd/cluster/cluster.go
+++ b/cmd/sealer/cmd/cluster/cluster.go
@@ -18,6 +18,6 @@ import "github.com/spf13/cobra"
 
 func NewClusterCommands() []*cobra.Command {
 	var clusterCommands []*cobra.Command
-	clusterCommands = append(clusterCommands, NewCheckCmd(), NewDeleteCmd(), NewJoinCmd(), NewRunCmd())
+	clusterCommands = append(clusterCommands, NewCheckCmd(), NewDeleteCmd(), NewJoinCmd(), NewRunCmd(), NewRunAPPCmd())
 	return clusterCommands
 }

--- a/cmd/sealer/cmd/cluster/run-app.go
+++ b/cmd/sealer/cmd/cluster/run-app.go
@@ -1,0 +1,144 @@
+// Copyright © 2021 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
+	"github.com/sealerio/sealer/common"
+	clusterruntime "github.com/sealerio/sealer/pkg/cluster-runtime"
+	"github.com/sealerio/sealer/pkg/clusterfile"
+	v12 "github.com/sealerio/sealer/pkg/define/image/v1"
+	"github.com/sealerio/sealer/pkg/define/options"
+	"github.com/sealerio/sealer/pkg/imagedistributor"
+	"github.com/sealerio/sealer/pkg/imageengine"
+	"github.com/sealerio/sealer/pkg/infradriver"
+	"github.com/sealerio/sealer/pkg/registry"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var appFlags *types.APPFlags
+var exampleForRunAppCmd = ``
+
+func NewRunAPPCmd() *cobra.Command {
+	runCmd := &cobra.Command{
+		Use:     "run-app",
+		Short:   "start to run an application cluster image",
+		Long:    `sealer run-app localhost/nginx:v1`,
+		Example: exampleForRunAppCmd,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var (
+				cf              clusterfile.Interface
+				clusterFileData []byte
+				err             error
+			)
+
+			//todo grab more cluster info from api server
+			clusterFileData, err = ioutil.ReadFile(common.GetDefaultClusterfile())
+			if err != nil {
+				return err
+			}
+
+			cf, err = clusterfile.NewClusterFile(clusterFileData)
+			if err != nil {
+				return err
+			}
+
+			cluster := cf.GetCluster()
+			infraDriver, err := infradriver.NewInfraDriver(&cluster)
+			if err != nil {
+				return err
+			}
+
+			var (
+				clusterHosts = infraDriver.GetHostIPList()
+				launchCmds   = appFlags.LaunchCmds
+				appImageName = args[0]
+			)
+
+			imageEngine, err := imageengine.NewImageEngine(options.EngineGlobalConfigurations{})
+			if err != nil {
+				return err
+			}
+
+			extension, err := imageEngine.GetSealerImageExtension(&options.GetImageAnnoOptions{ImageNameOrID: appImageName})
+			if err != nil {
+				return fmt.Errorf("failed to get cluster image extension: %s", err)
+			}
+
+			if extension.Type != v12.AppInstaller {
+				return fmt.Errorf("exit install process, wrong cluster image type: %s", extension.Type)
+			}
+
+			clusterHostsPlatform, err := infraDriver.GetHostsPlatform(clusterHosts)
+			if err != nil {
+				return err
+			}
+
+			imageMounter, err := imagedistributor.NewImageMounter(imageEngine, clusterHostsPlatform)
+			if err != nil {
+				return err
+			}
+
+			imageMountInfo, err := imageMounter.Mount(appImageName)
+			if err != nil {
+				return err
+			}
+
+			defer func() {
+				err = imageMounter.Umount(imageMountInfo)
+				if err != nil {
+					logrus.Errorf("failed to umount cluster image")
+				}
+			}()
+
+			distributor, err := imagedistributor.NewScpDistributor(imageMountInfo, infraDriver, nil)
+			if err != nil {
+				return err
+			}
+
+			//todo grab this config from cluster file, that's because it belongs to cluster level information
+			var registryConfig registry.RegConfig
+			var config = registry.Registry{
+				Domain: registry.DefaultDomain,
+				Port:   registry.DefaultPort,
+			}
+
+			registryConfig.LocalRegistry = &registry.LocalRegistry{
+				DataDir:    filepath.Join(infraDriver.GetClusterRootfsPath(), "registry"),
+				DeployHost: infraDriver.GetHostIPListByRole(common.MASTER)[0],
+				Registry:   config,
+			}
+
+			installer := clusterruntime.NewAppInstaller(infraDriver, distributor, extension, registryConfig)
+			err = installer.Install(infraDriver.GetHostIPListByRole(common.MASTER)[0], launchCmds)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	appFlags = &types.APPFlags{}
+	runCmd.Flags().StringSliceVar(&appFlags.LaunchCmds, "cmds", []string{}, "override default LaunchCmds of clusterimage")
+	//runCmd.Flags().StringSliceVar(&appFlags.LaunchArgs, "args", []string{}, "override default LaunchArgs of clusterimage")
+	return runCmd
+}

--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -120,8 +120,9 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			var (
-				clusterHosts     = infraDriver.GetHostIPList()
-				clusterImageName = cluster.Spec.Image
+				clusterLaunchCmds = infraDriver.GetClusterLaunchCmds()
+				clusterHosts      = infraDriver.GetHostIPList()
+				clusterImageName  = cluster.Spec.Image
 			)
 
 			clusterHostsPlatform, err := infraDriver.GetHostsPlatform(clusterHosts)
@@ -166,9 +167,11 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			runtimeConfig := &clusterruntime.RuntimeConfig{
-				Distributor: distributor,
-				ImageEngine: imageEngine,
-				Plugins:     plugins,
+				Distributor:       distributor,
+				ImageEngine:       imageEngine,
+				Plugins:           plugins,
+				ClusterLaunchCmds: clusterLaunchCmds,
+				ClusterImageImage: clusterImageName,
 			}
 
 			if cf.GetKubeadmConfig() != nil {

--- a/cmd/sealer/cmd/types/types.go
+++ b/cmd/sealer/cmd/types/types.go
@@ -29,3 +29,10 @@ type Flags struct {
 	CustomEnv  []string
 	CMDArgs    []string
 }
+
+type APPFlags struct {
+	// override default LaunchCmds of clusterimage
+	LaunchCmds []string
+	// maybe we can support to override default LaunchArgs of clusterimage to render LaunchCmds.
+	LaunchArgs []string
+}

--- a/common/common.go
+++ b/common/common.go
@@ -150,6 +150,10 @@ func GetDefaultClusterfile() string {
 	return filepath.Join(GetSealerWorkDir(), "Clusterfile")
 }
 
+func GetDefaultApplicationFile() string {
+	return filepath.Join(GetSealerWorkDir(), "application.json")
+}
+
 func DefaultRegistryAuthConfigDir() string {
 	return filepath.Join(GetHomeDir(), ".docker/config.json")
 }

--- a/pkg/cluster-runtime/apps.go
+++ b/pkg/cluster-runtime/apps.go
@@ -1,0 +1,135 @@
+// Copyright © 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterruntime
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"path/filepath"
+
+	"github.com/moby/buildkit/frontend/dockerfile/shell"
+	"github.com/sealerio/sealer/common"
+	containerruntime "github.com/sealerio/sealer/pkg/container-runtime"
+	v12 "github.com/sealerio/sealer/pkg/define/image/v1"
+	"github.com/sealerio/sealer/pkg/imagedistributor"
+	"github.com/sealerio/sealer/pkg/infradriver"
+	"github.com/sealerio/sealer/pkg/registry"
+	osutils "github.com/sealerio/sealer/utils/os"
+)
+
+type AppInstaller struct {
+	infraDriver    infradriver.InfraDriver
+	distributor    imagedistributor.Distributor
+	registryConfig registry.RegConfig
+	extension      v12.ImageExtension
+}
+
+func NewAppInstaller(infraDriver infradriver.InfraDriver, distributor imagedistributor.Distributor, extension v12.ImageExtension, registryConfig registry.RegConfig) AppInstaller {
+	return AppInstaller{
+		infraDriver:    infraDriver,
+		distributor:    distributor,
+		registryConfig: registryConfig,
+		extension:      extension,
+	}
+}
+
+func (i *AppInstaller) Install(master0 net.IP, cmds []string) error {
+	// distribute rootfs
+	if err := i.distributor.DistributeRootfs([]net.IP{master0}, i.infraDriver.GetClusterRootfsPath()); err != nil {
+		return err
+	}
+
+	registryConfigurator, err := registry.NewConfigurator(i.registryConfig, containerruntime.Info{}, i.infraDriver, i.distributor)
+	if err != nil {
+		return err
+	}
+
+	registryDriver, err := registryConfigurator.GetDriver()
+	if err != nil {
+		return err
+	}
+
+	err = registryDriver.UploadContainerImages2Registry()
+	if err != nil {
+		return err
+	}
+
+	if err = i.LaunchClusterImage(master0, cmds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i AppInstaller) LaunchClusterImage(master0 net.IP, launchCmds []string) error {
+	var (
+		cmds          []string
+		clusterRootfs = i.infraDriver.GetClusterRootfsPath()
+		ex            = shell.NewLex('\\')
+	)
+
+	if len(launchCmds) > 0 {
+		cmds = launchCmds
+	} else {
+		cmds = i.extension.Launch.Cmds
+	}
+
+	for _, value := range cmds {
+		if value == "" {
+			continue
+		}
+		cmdline, err := ex.ProcessWordWithMap(value, map[string]string{})
+		if err != nil {
+			return fmt.Errorf("failed to render launch cmd: %v", err)
+		}
+
+		if err = i.infraDriver.CmdAsync(master0, fmt.Sprintf(common.CdAndExecCmd, clusterRootfs, cmdline)); err != nil {
+			return err
+		}
+	}
+
+	return i.save()
+}
+
+// todo save image info to disk or api server, we need new interface to do this.
+func (i AppInstaller) save() error {
+	var extensionList []v12.ImageExtension
+	applicationFile := common.GetDefaultApplicationFile()
+
+	if osutils.IsFileExist(applicationFile) {
+		b, err := ioutil.ReadFile(filepath.Clean(applicationFile))
+		if err != nil {
+			return err
+		}
+
+		b = bytes.TrimSpace(b)
+		if len(b) != 0 {
+			if err := json.Unmarshal(b, &extensionList); err != nil {
+				return fmt.Errorf("failed to load default application file %s: %v", applicationFile, err)
+			}
+		}
+	}
+
+	extensionList = append(extensionList, i.extension)
+	content, err := json.Marshal(extensionList)
+	if err != nil {
+		return fmt.Errorf("failed to marshal image extension: %v", err)
+	}
+
+	return osutils.NewCommonWriter(applicationFile).WriteFile(content)
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

as we know , we use sealer run to launch cluster image including k8s cluster and build-in apps. meanwhile, sealer also support to build cluster image which image type is application that will only launch build-in apps.

So I suggest that we can separate these two sealer run process and support an additional command.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
