### PR TITLE
bugfix: image save use ociv1 format

### DIFF
--- a/cmd/sealer/cmd/image/save.go
+++ b/cmd/sealer/cmd/image/save.go
@@ -52,7 +52,7 @@ func NewSaveCmd() *cobra.Command {
 	}
 	saveOpts = &options.SaveOptions{}
 	flags := saveCmd.Flags()
-	flags.StringVar(&saveOpts.Format, "format", buildah.V2s2Archive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
+	flags.StringVar(&saveOpts.Format, "format", buildah.OCIArchive, "Save image to oci-archive, oci-dir (directory with oci manifest type), docker-archive, docker-dir (directory with v2s2 manifest type)")
 	flags.StringVarP(&saveOpts.Output, "output", "o", "", "Write image to a specified file")
 	flags.BoolVarP(&saveOpts.Quiet, "quiet", "q", false, "Suppress the output")
 	flags.BoolVar(&saveOpts.Compress, "compress", false, "Compress tarball image layers when saving to a directory using the 'dir' transport. (default is same compression type as source)")

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -365,19 +365,15 @@ func (d *SSHInfraDriver) Execute(hosts []net.IP, f func(host net.IP) error) erro
 }
 
 func checkAllHostsSameFamily(nodeList []net.IP) error {
-	hasIPV4 := false
-	hasIPV6 := false
-	for _, ip := range nodeList {
-		if k8snet.IsIPv4(ip) {
-			hasIPV4 = true
-		} else if k8snet.IsIPv6(ip) {
-			hasIPV6 = true
+	var netFamily bool
+	for i, ip := range nodeList {
+		if i == 0 {
+			netFamily = k8snet.IsIPv4(ip)
+		}
+
+		if netFamily != k8snet.IsIPv4(ip) {
+			return fmt.Errorf("all hosts must be in same ip family, but the node list given are mixed with ipv4 and ipv6: %v", nodeList)
 		}
 	}
-
-	if hasIPV4 && hasIPV6 {
-		return fmt.Errorf("all hosts must be in same ip family, but the node list given are mixed with ipv4 and ipv6: %v", nodeList)
-	}
-
 	return nil
 }

--- a/pkg/infradriver/ssh_infradriver_test.go
+++ b/pkg/infradriver/ssh_infradriver_test.go
@@ -137,3 +137,48 @@ func TestSSHInfraDriver_GetClusterInfo(t *testing.T) {
 		"test_node_env_key": "test_node_env_value",
 	})
 }
+
+func TestCheckAllHostsSameFamily(t *testing.T) {
+	type args struct {
+		data    []net.IP
+		wanterr bool
+	}
+
+	var tests = []struct {
+		name string
+		args args
+	}{
+		{
+			"test all ipv4",
+			args{
+				data:    []net.IP{net.IPv4(192, 168, 0, 1), net.IPv4(192, 168, 0, 2), net.IPv4(192, 168, 0, 3)},
+				wanterr: false,
+			},
+		},
+		{
+			"test all ipv6",
+			args{
+				data:    []net.IP{net.ParseIP("2408:4003:10bb:6a01:83b9:6360:c66d:ed57"), net.ParseIP("2408:4003:10bb:6a01:83b9:6360:c66d:ed58")},
+				wanterr: false,
+			},
+		},
+		{
+			"test mixed ip address",
+			args{
+				data:    []net.IP{net.IPv4(192, 168, 0, 1), net.ParseIP("2408:4003:10bb:6a01:83b9:6360:c66d:ed57")},
+				wanterr: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkAllHostsSameFamily(tt.args.data)
+			if tt.args.wanterr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

set default sealer save format as `oci-archive`, thats because we need `ImageAnnotations` to launch cluster image.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
