### PR TITLE
When sealer run, clean /var/lib/sealer/data/linux_amd64_ if exists

### DIFF
--- a/pkg/imagedistributor/mount.go
+++ b/pkg/imagedistributor/mount.go
@@ -17,12 +17,14 @@ package imagedistributor
 import (
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/common"
 	imagecommon "github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	v1 "github.com/sealerio/sealer/types/api/v1"
+	osi "github.com/sealerio/sealer/utils/os"
 	"github.com/sealerio/sealer/utils/os/fs"
 )
 
@@ -33,6 +35,12 @@ type buildAhMounter struct {
 func (b buildAhMounter) Mount(imageName string, platform v1.Platform) (string, error) {
 	path := platform.OS + "_" + platform.Architecture + "_" + platform.Variant
 	mountDir := filepath.Join(common.DefaultSealerDataDir, path)
+	if osi.IsFileExist(mountDir) {
+		err := os.RemoveAll(mountDir)
+		if err != nil {
+			return "", err
+		}
+	}
 	if err := b.imageEngine.Pull(&imagecommon.PullOptions{
 		Quiet:      false,
 		PullPolicy: "missing",


### PR DESCRIPTION
Signed-off-by: zhy76 <958474674@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Bug: if run fail, need clean /var/lib/sealer/data/linux_amd64_ manualy

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
#1801 
### Describe how you did it
at mount.go, if /var/lib/sealer/data/linux_amd64_ exists,remove it before mount

### Describe how to verify it
I made a test,if linux_amd64_ exits, we can see it can be deleted before mount:
![image](https://user-images.githubusercontent.com/56665618/197967190-60cce315-f493-4bd2-a58f-6315f7e8c72f.png)

### Special notes for reviews
