### PR TITLE
fix:If join a node fail, it will be stored in ClusterFile and can't join it again

### DIFF
--- a/cmd/sealer/cmd/cluster/scale-up.go
+++ b/cmd/sealer/cmd/cluster/scale-up.go
@@ -76,6 +76,9 @@ func NewScaleUpCmd() *cobra.Command {
 				return err
 			}
 
+			//store the Cluster as CfSnapshot for rollback
+			cf.CommitSnapshot()
+
 			cluster := cf.GetCluster()
 			if err = utils.ConstructClusterForScaleUp(&cluster, ScaleUpFlags, scaleUpMasterIPList, scaleUpNodeIPList); err != nil {
 				return err
@@ -86,6 +89,14 @@ func NewScaleUpCmd() *cobra.Command {
 			if err = cf.SaveAll(); err != nil {
 				return err
 			}
+
+			defer func() {
+				if err == nil {
+					return
+				}
+				//if there exits an error,rollback the ClusterFile to the default file
+				cf.RollBackClusterFile()
+			}()
 
 			infraDriver, err := infradriver.NewInfraDriver(&cluster)
 			if err != nil {
@@ -117,9 +128,8 @@ func NewScaleUpCmd() *cobra.Command {
 				return err
 			}
 			defer func() {
-				err = imageMounter.Umount(imageMountInfo)
-				if err != nil {
-					logrus.Errorf("failed to umount cluster image")
+				if e := imageMounter.Umount(imageMountInfo); e != nil {
+					logrus.Errorf("failed to umount cluster image: %v", e)
 				}
 			}()
 


### PR DESCRIPTION
fix:If join a node fail, it will be stored in ClusterFile and can't join it again

Signed-off-by: zhy76 <958474674@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix:If join a node fail, it will be stored in ClusterFile and can't join it again, unless remove it from ClusterFile manually

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
#1802  
### Describe how you did it
At the beginning of the sealer join cmd,I store the default Clusterfile,if there exits an error,restore the ClusterFile to the default file,the second defer func will infect the first defer func and the value of 'err',so I change it to 'e'.

### Describe how to verify it
I have made some tests,if cmd fail,the Clusterfile will be the default one:
before sealer join:
![image](https://user-images.githubusercontent.com/56665618/198295226-dc4c1844-8da2-4df2-a0bc-dccec9dea2a2.png)
executing sealer join:
![image](https://user-images.githubusercontent.com/56665618/198295278-cb96451f-04bf-4695-b112-7a570600e30c.png)
if sealer join cmd fail,the Clusterfile will be the default:
![image](https://user-images.githubusercontent.com/56665618/198295342-6cad1efa-5f1c-458b-a762-9bd28a240e67.png)

### Special notes for reviews
