### PR TITLE
Fix: 1. should not trim Config's empty line;     2. if no registry dir exist in AppImage, should skip scp it.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,7 +67,6 @@ func (c *Dumper) Dump(configs []v1.Config) error {
 
 func (c *Dumper) WriteFiles(configs []v1.Config) error {
 	for _, config := range configs {
-		config.Spec.Data = strings.TrimSuffix(config.Spec.Data, "\n")
 		//#nosec
 		if err := NewProcessorsAndRun(&config); err != nil {
 			return err

--- a/pkg/imagedistributor/scp_distributor.go
+++ b/pkg/imagedistributor/scp_distributor.go
@@ -47,6 +47,9 @@ type scpDistributor struct {
 
 func (s *scpDistributor) DistributeRegistry(deployHost net.IP, dataDir string) error {
 	for _, info := range s.imageMountInfo {
+		if !osi.IsFileExist(filepath.Join(info.MountDir, RegistryDirName)) {
+			continue
+		}
 		err := s.infraDriver.Copy(deployHost, filepath.Join(info.MountDir, RegistryDirName), dataDir)
 		if err != nil {
 			return fmt.Errorf("failed to copy registry data %s: %v", info.MountDir, err)


### PR DESCRIPTION
1. should not trim Config's empty line;
2. if no registry dir exist in AppImage, should skip scp it.

Signed-off-by: huaiyou <huaiyou.cyz@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
