### PR TITLE
Support skip clean hooks when cluster workspace not exist.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -135,7 +135,8 @@ const (
 const APIServerDomain = "apiserver.cluster.local"
 
 const (
-	CdAndExecCmd = "cd %s && %s"
+	CdAndExecCmd        = "cd %s && %s"
+	CdIfExistAndExecCmd = "if [ ! -d %s ];then exit 0;fi; cd %s && %s"
 )
 
 const (

--- a/pkg/container-runtime/docker.go
+++ b/pkg/container-runtime/docker.go
@@ -40,7 +40,7 @@ func (d *DockerInstaller) InstallOn(hosts []net.IP) error {
 }
 
 func (d *DockerInstaller) UnInstallFrom(hosts []net.IP) error {
-	cleanCmd := fmt.Sprintf("bash %s", filepath.Join(d.rootfs, "scripts", "uninstall-docker.sh"))
+	cleanCmd := fmt.Sprintf("if ! which docker;then exit 0;fi; bash %s", filepath.Join(d.rootfs, "scripts", "uninstall-docker.sh"))
 	for _, ip := range hosts {
 		err := d.driver.CmdAsync(ip, cleanCmd)
 		if err != nil {

--- a/test/testhelper/helper.go
+++ b/test/testhelper/helper.go
@@ -33,7 +33,7 @@ func Start(cmdLine string) (*gexec.Session, error) {
 		return nil, errors.New("failed to start cmd, line is empty")
 	}
 	cmdLine = fmt.Sprintf("sudo -E %s", cmdLine)
-	execCmd := exec.Command("/bin/sh", "-c", cmdLine) // #nosec
+	execCmd := exec.Command("/bin/bash", "-c", cmdLine) // #nosec
 	_, err := io.WriteString(ginkgo.GinkgoWriter, fmt.Sprintf("%s\n", cmdLine))
 	if err != nil {
 		return nil, err

--- a/utils/exec/exec.go
+++ b/utils/exec/exec.go
@@ -64,9 +64,9 @@ func RunSimpleCmd(cmd string) (string, error) {
 	}
 	var result []byte
 	if username != common.ROOT {
-		result, err = exec.Command(SUDO, "/bin/sh", "-c", cmd).CombinedOutput() // #nosec
+		result, err = exec.Command(SUDO, "/bin/bash", "-c", cmd).CombinedOutput() // #nosec
 	} else {
-		result, err = exec.Command("/bin/sh", "-c", cmd).CombinedOutput() // #nosec
+		result, err = exec.Command("/bin/bash", "-c", cmd).CombinedOutput() // #nosec
 	}
 	if err != nil {
 		logrus.Debugf("failed to execute command(%s): error(%v)", cmd, err)

--- a/utils/ssh/sshcmd.go
+++ b/utils/ssh/sshcmd.go
@@ -49,7 +49,7 @@ func (s *SSH) CmdAsync(host net.IP, cmds ...string) error {
 
 	if utilsnet.IsLocalIP(host, s.LocalAddress) {
 		execFunc = func(cmd string) error {
-			c := exec.Command("/bin/sh", "-c", cmd)
+			c := exec.Command("/bin/bash", "-c", cmd)
 			stdout, err := c.StdoutPipe()
 			if err != nil {
 				return err
@@ -128,7 +128,7 @@ func (s *SSH) Cmd(host net.IP, cmd string) ([]byte, error) {
 	var stdoutContent, stderrContent bytes.Buffer
 
 	if utilsnet.IsLocalIP(host, s.LocalAddress) {
-		localCmd := exec.Command("/bin/sh", "-c", cmd)
+		localCmd := exec.Command("/bin/bash", "-c", cmd)
 		localCmd.Stdout = &stdoutContent
 		localCmd.Stderr = &stderrContent
 		if err := localCmd.Run(); err != nil {


### PR DESCRIPTION
Signed-off-by: huaiyou <huaiyou.cyz@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Support skip clean hooks when cluster workspace not exist. This can improve the robust of clean.

Sometimes the directory has been cleaned up, but if the hook is executed again, an error will be reported because there is no file. This makes the logic for cleaning up nodes non-reentrant. So changed to, if there is no working directory, skip hook execution

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
