### PR TITLE
sealer run-app supports concurrent  run 

### DIFF
--- a/cmd/sealer/cmd/cluster/apply.go
+++ b/cmd/sealer/cmd/cluster/apply.go
@@ -158,7 +158,7 @@ func createNewCluster(clusterImageName string, infraDriver infradriver.InfraDriv
 	}
 
 	defer func() {
-		err = imageMounter.Umount(imageMountInfo)
+		err = imageMounter.Umount(clusterImageName, imageMountInfo)
 		if err != nil {
 			logrus.Errorf("failed to umount cluster image")
 		}
@@ -227,7 +227,7 @@ func scaleUpCluster(clusterImageName string, scaleUpMasterIPList, scaleUpNodeIPL
 		return err
 	}
 	defer func() {
-		err = imageMounter.Umount(imageMountInfo)
+		err = imageMounter.Umount(clusterImageName, imageMountInfo)
 		if err != nil {
 			logrus.Errorf("failed to umount cluster image")
 		}

--- a/cmd/sealer/cmd/cluster/delete.go
+++ b/cmd/sealer/cmd/cluster/delete.go
@@ -146,7 +146,7 @@ func deleteCluster(workClusterfile string) error {
 		return err
 	}
 	defer func() {
-		err = imageMounter.Umount(imageMountInfo)
+		err = imageMounter.Umount(cluster.Spec.Image, imageMountInfo)
 		if err != nil {
 			logrus.Errorf("failed to umount cluster image")
 		}
@@ -269,7 +269,7 @@ func scaleDownCluster(masters, workers, workClusterfile string) error {
 		return err
 	}
 	defer func() {
-		err = imageMounter.Umount(imageMountInfo)
+		err = imageMounter.Umount(cluster.Spec.Image, imageMountInfo)
 		if err != nil {
 			logrus.Errorf("failed to umount cluster image")
 		}

--- a/cmd/sealer/cmd/cluster/join.go
+++ b/cmd/sealer/cmd/cluster/join.go
@@ -129,7 +129,7 @@ func NewJoinCmd() *cobra.Command {
 				return err
 			}
 			defer func() {
-				if e := imageMounter.Umount(imageMountInfo); e != nil {
+				if e := imageMounter.Umount(clusterImageName, imageMountInfo); e != nil {
 					logrus.Errorf("failed to umount cluster image: %v", e)
 				}
 			}()

--- a/cmd/sealer/cmd/cluster/run-app.go
+++ b/cmd/sealer/cmd/cluster/run-app.go
@@ -112,7 +112,7 @@ func installApplication(appImageName string, launchCmds []string, extension v12.
 	}
 
 	defer func() {
-		err = imageMounter.Umount(imageMountInfo)
+		err = imageMounter.Umount(appImageName, imageMountInfo)
 		if err != nil {
 			logrus.Errorf("failed to umount cluster image")
 		}

--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -148,7 +148,7 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			defer func() {
-				err = imageMounter.Umount(imageMountInfo)
+				err = imageMounter.Umount(clusterImageName, imageMountInfo)
 				if err != nil {
 					logrus.Errorf("failed to umount cluster image")
 				}

--- a/cmd/sealer/cmd/cluster/scale-up.go
+++ b/cmd/sealer/cmd/cluster/scale-up.go
@@ -128,7 +128,7 @@ func NewScaleUpCmd() *cobra.Command {
 				return err
 			}
 			defer func() {
-				if e := imageMounter.Umount(imageMountInfo); e != nil {
+				if e := imageMounter.Umount(clusterImageName, imageMountInfo); e != nil {
 					logrus.Errorf("failed to umount cluster image: %v", e)
 				}
 			}()

--- a/pkg/cluster-runtime/installer.go
+++ b/pkg/cluster-runtime/installer.go
@@ -127,7 +127,7 @@ func (i *Installer) Install() error {
 	}
 
 	// distribute rootfs
-	if err := i.Distributor.DistributeRootfs(all, i.infraDriver.GetClusterRootfsPath()); err != nil {
+	if err := i.Distributor.Distribute(all, i.infraDriver.GetClusterRootfsPath()); err != nil {
 		return err
 	}
 

--- a/pkg/cluster-runtime/scale.go
+++ b/pkg/cluster-runtime/scale.go
@@ -28,7 +28,7 @@ func (i *Installer) ScaleUp(newMasters, newWorkers []net.IP) (registry.Driver, r
 	all := append(newMasters, newWorkers...)
 
 	// distribute rootfs
-	if err := i.Distributor.DistributeRootfs(all, i.infraDriver.GetClusterRootfsPath()); err != nil {
+	if err := i.Distributor.Distribute(all, i.infraDriver.GetClusterRootfsPath()); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/imagedistributor/interface.go
+++ b/pkg/imagedistributor/interface.go
@@ -21,8 +21,8 @@ import (
 )
 
 type Distributor interface {
-	// DistributeRootfs each files under mounted cluster image directory to target hosts.
-	DistributeRootfs(hosts []net.IP, rootfsPath string) error
+	// Distribute each files under mounted cluster image directory to target hosts.
+	Distribute(hosts []net.IP, dest string) error
 	// DistributeRegistry each files under registry directory to target hosts.
 	DistributeRegistry(deployHost net.IP, dataDir string) error
 	// Restore will do some clean works via infra driver, like delete rootfs.

--- a/pkg/imagedistributor/mount.go
+++ b/pkg/imagedistributor/mount.go
@@ -19,13 +19,17 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
-	"github.com/sealerio/sealer/common"
 	imagecommon "github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	osi "github.com/sealerio/sealer/utils/os"
 	"github.com/sealerio/sealer/utils/os/fs"
+)
+
+const (
+	mountBaseDir = "/var/lib/sealer/data/mount"
 )
 
 type buildAhMounter struct {
@@ -34,7 +38,7 @@ type buildAhMounter struct {
 
 func (b buildAhMounter) Mount(imageName string, platform v1.Platform) (string, error) {
 	path := platform.OS + "_" + platform.Architecture + "_" + platform.Variant
-	mountDir := filepath.Join(common.DefaultSealerDataDir, path)
+	mountDir := filepath.Join(imageMountDir(imageName), path)
 	if osi.IsFileExist(mountDir) {
 		err := os.RemoveAll(mountDir)
 		if err != nil {
@@ -47,6 +51,11 @@ func (b buildAhMounter) Mount(imageName string, platform v1.Platform) (string, e
 		Image:      imageName,
 		Platform:   platform.ToString(),
 	}); err != nil {
+		return "", err
+	}
+
+	// make sure base mount Dir is existed.
+	if err := fs.FS.MkdirAll(filepath.Dir(mountDir)); err != nil {
 		return "", err
 	}
 
@@ -108,12 +117,16 @@ func (c ImagerMounter) Mount(imageName string) ([]ClusterImageMountInfo, error) 
 	return imageMountInfos, nil
 }
 
-func (c ImagerMounter) Umount(imageMountInfo []ClusterImageMountInfo) error {
+func (c ImagerMounter) Umount(imageName string, imageMountInfo []ClusterImageMountInfo) error {
 	for _, info := range imageMountInfo {
 		err := c.Mounter.Umount(info.MountDir)
 		if err != nil {
 			return fmt.Errorf("failed to umount %s:%v", info.MountDir, err)
 		}
+	}
+	// delete all mounted images
+	if err := fs.FS.RemoveAll(imageMountDir(imageName)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -124,4 +137,8 @@ func NewImageMounter(imageEngine imageengine.Interface, hostsPlatform map[v1.Pla
 	}
 	c.Mounter = NewBuildAhMounter(imageEngine)
 	return c, nil
+}
+
+func imageMountDir(name string) string {
+	return filepath.Join(mountBaseDir, strings.ReplaceAll(name, "/", "_"))
 }

--- a/pkg/imagedistributor/mount_test.go
+++ b/pkg/imagedistributor/mount_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagedistributor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageMountDir(t *testing.T) {
+	tests := []struct {
+		testName   string
+		imageName  string
+		wantedPath string
+	}{
+		{testName: "image name with tag", imageName: "nginx:v1", wantedPath: "/var/lib/sealer/data/mount/nginx:v1"},
+		{testName: "image name with repo and tag", imageName: "library/nginx:v1", wantedPath: "/var/lib/sealer/data/mount/library_nginx:v1"},
+		{testName: "image name with domain repo and tag", imageName: "docker.io/library/nginx:v1", wantedPath: "/var/lib/sealer/data/mount/docker.io_library_nginx:v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			mountedPath := imageMountDir(tt.imageName)
+			assert.Equal(t, tt.wantedPath, mountedPath)
+		})
+	}
+}

--- a/pkg/imagedistributor/scp_distributor.go
+++ b/pkg/imagedistributor/scp_distributor.go
@@ -59,7 +59,7 @@ func (s *scpDistributor) DistributeRegistry(deployHost net.IP, dataDir string) e
 	return nil
 }
 
-func (s *scpDistributor) DistributeRootfs(hosts []net.IP, rootfsPath string) error {
+func (s *scpDistributor) Distribute(hosts []net.IP, dest string) error {
 	for _, info := range s.imageMountInfo {
 		if err := s.dumpConfigToRootfs(info.MountDir); err != nil {
 			return err
@@ -75,7 +75,7 @@ func (s *scpDistributor) DistributeRootfs(hosts []net.IP, rootfsPath string) err
 		}
 
 		for _, target := range targetDirs {
-			err = s.copyRootfs(target, filepath.Join(rootfsPath, filepath.Base(target)), info.Hosts)
+			err = s.copyRootfs(target, filepath.Join(dest, filepath.Base(target)), info.Hosts)
 			if err != nil {
 				return err
 			}

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strings"
 
 	"github.com/containers/buildah/util"
@@ -337,11 +338,11 @@ func (d *SSHInfraDriver) GetHostsPlatform(hosts []net.IP) (map[v1.Platform][]net
 }
 
 func (d *SSHInfraDriver) GetClusterRootfsPath() string {
-	return common.DefaultTheClusterRootfsDir(d.clusterName)
+	return filepath.Join(common.DefaultSealerDataDir, d.clusterName, "rootfs")
 }
 
 func (d *SSHInfraDriver) GetClusterBasePath() string {
-	return common.DefaultClusterBaseDir(d.clusterName)
+	return filepath.Join(common.DefaultSealerDataDir, d.clusterName)
 }
 
 func (d *SSHInfraDriver) Execute(hosts []net.IP, f func(host net.IP) error) error {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

At present, our cluster image data is mixed with application image data and base image data, If we run multiple images at the same time, there will be conflicts.

1. Detach the mount directory
all imagedata mount directory will under below directory:
`/var/lib/sealer/data/mount/${imageName}/${platform}`

all application imagedata rootfs directory will under below directory:
`var/lib/sealer/data/${imageName}/rootfs/application/apps`

all basefs  imagedata directory will under below directory:
`var/lib/sealer/data/${imageName}/rootfs`

2. add a file lock on .sealer/application.json

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
