### PR TITLE
refactor: replace the deprecated package io/ioutil with os and io

### DIFF
--- a/build/kubefile/parser/app_handler.go
+++ b/build/kubefile/parser/app_handler.go
@@ -16,7 +16,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -72,7 +72,7 @@ func (kp *KubefileParser) processApp(node *Node, result *KubefileResult) error {
 	// 2. download remote files to the temp dir
 	// 3. append the temp files to filesToCopy
 	if len(remoteFiles) > 0 {
-		remoteCxtAbs, err := ioutil.TempDir(kp.buildContext, "sealer-remote-files")
+		remoteCxtAbs, err := os.MkdirTemp(kp.buildContext, "sealer-remote-files")
 		if err != nil {
 			return errors.Errorf("failed to create remote context: %s", err)
 		}

--- a/build/kubefile/parser/utils.go
+++ b/build/kubefile/parser/utils.go
@@ -17,7 +17,6 @@ package parser
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,7 +103,7 @@ func isHelm(sources ...string) (bool, error) {
 				return true, nil
 			}
 
-			files, err := ioutil.ReadDir(source)
+			files, err := os.ReadDir(source)
 			if err != nil {
 				return false, fmt.Errorf("failed to read dir (%s) in isHelm: %s", source, err)
 			}

--- a/cmd/sealer/cmd/cluster/apply.go
+++ b/cmd/sealer/cmd/cluster/apply.go
@@ -16,8 +16,8 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -70,7 +70,7 @@ func NewApplyCmd() *cobra.Command {
 				return fmt.Errorf("you must input Clusterfile")
 			}
 
-			clusterFileData, err = ioutil.ReadFile(filepath.Clean(applyClusterFile))
+			clusterFileData, err = os.ReadFile(filepath.Clean(applyClusterFile))
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/cert.go
+++ b/cmd/sealer/cmd/cluster/cert.go
@@ -16,7 +16,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -53,7 +53,7 @@ func NewCertCmd() *cobra.Command {
 			}
 
 			workClusterfile := common.GetDefaultClusterfile()
-			clusterFileData, err := ioutil.ReadFile(filepath.Clean(workClusterfile))
+			clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/delete.go
+++ b/cmd/sealer/cmd/cluster/delete.go
@@ -16,8 +16,8 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -31,7 +31,7 @@ import (
 	"github.com/sealerio/sealer/pkg/infradriver"
 	"github.com/sealerio/sealer/utils"
 	netutils "github.com/sealerio/sealer/utils/net"
-	"github.com/sealerio/sealer/utils/os"
+	osutils "github.com/sealerio/sealer/utils/os"
 	"github.com/sealerio/sealer/utils/os/fs"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -96,11 +96,11 @@ func NewDeleteCmd() *cobra.Command {
 }
 
 func deleteCluster(workClusterfile string) error {
-	if !os.IsFileExist(workClusterfile) {
+	if !osutils.IsFileExist(workClusterfile) {
 		logrus.Info("no cluster found")
 		return nil
 	}
-	clusterFileData, err := ioutil.ReadFile(filepath.Clean(workClusterfile))
+	clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func scaleDownCluster(masters, workers, workClusterfile string) error {
 		return fmt.Errorf("failed to parse ip string to net IP list: %v", err)
 	}
 
-	clusterFileData, err := ioutil.ReadFile(filepath.Clean(workClusterfile))
+	clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
 	if err != nil {
 		return err
 	}

--- a/cmd/sealer/cmd/cluster/join.go
+++ b/cmd/sealer/cmd/cluster/join.go
@@ -16,7 +16,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -67,7 +67,7 @@ func NewJoinCmd() *cobra.Command {
 			}
 
 			workClusterfile := common.GetDefaultClusterfile()
-			clusterFileData, err := ioutil.ReadFile(filepath.Clean(workClusterfile))
+			clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/run-app.go
+++ b/cmd/sealer/cmd/cluster/run-app.go
@@ -16,7 +16,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -52,7 +52,7 @@ func NewRunAPPCmd() *cobra.Command {
 			)
 
 			//todo grab more cluster info from api server
-			clusterFileData, err = ioutil.ReadFile(common.GetDefaultClusterfile())
+			clusterFileData, err = os.ReadFile(common.GetDefaultClusterfile())
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -16,7 +16,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -76,7 +76,7 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			if clusterFile != "" {
-				clusterFileData, err = ioutil.ReadFile(filepath.Clean(clusterFile))
+				clusterFileData, err = os.ReadFile(filepath.Clean(clusterFile))
 				if err != nil {
 					return err
 				}

--- a/cmd/sealer/cmd/cluster/scale-up.go
+++ b/cmd/sealer/cmd/cluster/scale-up.go
@@ -16,7 +16,7 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -66,7 +66,7 @@ func NewScaleUpCmd() *cobra.Command {
 			}
 
 			workClusterfile := common.GetDefaultClusterfile()
-			clusterFileData, err := ioutil.ReadFile(filepath.Clean(workClusterfile))
+			clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/image/build.go
+++ b/cmd/sealer/cmd/image/build.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -295,7 +294,7 @@ func applyRegistryToImage(imageID, tag, manifest string, platform v1.Platform, e
 }
 
 func saveDockerfileAsTempfile(dockerFileContent string) (string, error) {
-	f, err := ioutil.TempFile("/tmp", "sealer-dockerfile")
+	f, err := os.CreateTemp("/tmp", "sealer-dockerfile")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cluster-runtime/hook.go
+++ b/pkg/cluster-runtime/hook.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -261,7 +260,7 @@ func LoadPluginsFromFile(pluginPath string) ([]v1.Plugin, error) {
 		return nil, nil
 	}
 
-	files, err := ioutil.ReadDir(pluginPath)
+	files, err := os.ReadDir(pluginPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to ReadDir plugin dir %s: %v", pluginPath, err)
 	}
@@ -284,7 +283,7 @@ func LoadPluginsFromFile(pluginPath string) ([]v1.Plugin, error) {
 
 func decodePluginFile(pluginFile string) ([]v1.Plugin, error) {
 	var plugins []v1.Plugin
-	data, err := ioutil.ReadFile(filepath.Clean(pluginFile))
+	data, err := os.ReadFile(filepath.Clean(pluginFile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/clusterfile/clusterfile_test.go
+++ b/pkg/clusterfile/clusterfile_test.go
@@ -15,7 +15,6 @@
 package clusterfile
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -121,7 +120,7 @@ func TestSaveAll(t *testing.T) {
 			if err := clusterFile.SaveAll(); err != nil {
 				t.Errorf("failed to save all file, error is:(%v)", err)
 			}
-			clusterFileData, err := ioutil.ReadFile(filepath.Clean(clusterFilePath))
+			clusterFileData, err := os.ReadFile(filepath.Clean(clusterFilePath))
 			if err != nil {
 				t.Errorf("failed to read cluster file, error is:(%v)", err)
 			}

--- a/pkg/imagedistributor/scp_distributor.go
+++ b/pkg/imagedistributor/scp_distributor.go
@@ -17,7 +17,7 @@ package imagedistributor
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/sealerio/sealer/pkg/config"
 	"github.com/sealerio/sealer/pkg/env"
@@ -88,7 +88,7 @@ func (s *scpDistributor) Distribute(hosts []net.IP, dest string) error {
 func (s *scpDistributor) filterRootfs(mountDir string) ([]string, error) {
 	var AllMountFiles []string
 
-	files, err := ioutil.ReadDir(mountDir)
+	files, err := os.ReadDir(mountDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dir %s: %s", mountDir, err)
 	}

--- a/pkg/registry/singleton.go
+++ b/pkg/registry/singleton.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -385,7 +384,7 @@ func (c *localSingletonConfigurator) configureDaemonService(hosts []net.IP) erro
 func (c *localSingletonConfigurator) configureDockerDaemonService(endpoint, daemonFile string) error {
 	var daemonConf DaemonConfig
 
-	b, err := ioutil.ReadFile(filepath.Clean(daemonFile))
+	b, err := os.ReadFile(filepath.Clean(daemonFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/kubernetes/init.go
+++ b/pkg/runtime/kubernetes/init.go
@@ -17,7 +17,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -66,7 +65,7 @@ func (k *Runtime) initKubeadmConfig(masters []net.IP) (kubeadm.KubeadmConfig, er
 	}
 
 	localTmpFile := "/tmp/kubeadm.yaml"
-	if err = ioutil.WriteFile(localTmpFile, bs, 0600); err != nil {
+	if err = os.WriteFile(localTmpFile, bs, 0600); err != nil {
 		return kubeadm.KubeadmConfig{}, err
 	}
 

--- a/pkg/runtime/kubernetes/runtime.go
+++ b/pkg/runtime/kubernetes/runtime.go
@@ -18,8 +18,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/common"
@@ -189,7 +189,7 @@ func (k *Runtime) dumpKubeConfigIntoCluster(master0 net.IP) error {
 		return err
 	}
 
-	kubeConfigContent, err := ioutil.ReadFile(AdminKubeConfPath)
+	kubeConfigContent, err := os.ReadFile(AdminKubeConfPath)
 	if err != nil {
 		return err
 	}

--- a/utils/os/fs/filesystem_test.go
+++ b/utils/os/fs/filesystem_test.go
@@ -15,7 +15,6 @@
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ func TestRenameDir(t *testing.T) {
 
 	filename := "tmp-file"
 	data := []byte("i am a tmp file\n")
-	if err := ioutil.WriteFile(filepath.Join(oldPath, filename), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(oldPath, filename), data, 0644); err != nil {
 		t.Fatalf("WriteFile %s: %v", filename, err)
 	}
 
@@ -92,7 +91,7 @@ func TestRenameDir(t *testing.T) {
 				t.Errorf("Rename() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			content, err := ioutil.ReadFile(filepath.Join(tt.args.newPath, filename))
+			content, err := os.ReadFile(filepath.Join(tt.args.newPath, filename))
 			assert.NoErrorf(t, err, "failed to load file content form new path")
 			assert.Equal(t, tt.args.fileContent, content)
 		})


### PR DESCRIPTION
Signed-off-by: Lancelot <1984737645@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. [https://pkg.go.dev/io/ioutil](https://pkg.go.dev/io/ioutil)

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Replaces:
```
ioutil.TempDir => os.MkdirTemp
ioutil.ReadDir => os.ReadDir
ioutil.ReadFile => os.ReadFile
ioutil.ReadAll => io.ReadAll
ioutil.TempFile => os.CreateTemp
ioutil.WriteFile => os.WriteFile
```
Same as  #1759 
### Describe how to verify it

Functionally zero changes to code.

### Special notes for reviews
