### PR TITLE
feat: save clusterfile to the cluster 

### DIFF
--- a/cmd/sealer/cmd/cluster/cert.go
+++ b/cmd/sealer/cmd/cluster/cert.go
@@ -16,11 +16,8 @@ package cluster
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	"github.com/sealerio/sealer/pkg/infradriver"
 	"github.com/spf13/cobra"
@@ -52,13 +49,7 @@ func NewCertCmd() *cobra.Command {
 				return fmt.Errorf("IP address or DNS domain needed for cert Subject Alternative Names")
 			}
 
-			workClusterfile := common.GetDefaultClusterfile()
-			clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
-			if err != nil {
-				return err
-			}
-
-			cf, err := clusterfile.NewClusterFile(clusterFileData)
+			cf, err := clusterfile.NewClusterFile(nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/join.go
+++ b/cmd/sealer/cmd/cluster/join.go
@@ -16,16 +16,13 @@ package cluster
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
 	"github.com/sealerio/sealer/cmd/sealer/cmd/utils"
 	"github.com/sealerio/sealer/common"
-	clusterruntime "github.com/sealerio/sealer/pkg/cluster-runtime"
 	"github.com/sealerio/sealer/pkg/clusterfile"
 	imagecommon "github.com/sealerio/sealer/pkg/define/options"
-	"github.com/sealerio/sealer/pkg/imagedistributor"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/sealerio/sealer/pkg/infradriver"
 	"github.com/sirupsen/logrus"
@@ -66,19 +63,10 @@ func NewJoinCmd() *cobra.Command {
 				return fmt.Errorf("failed to parse ip string to net IP list: %v", err)
 			}
 
-			workClusterfile := common.GetDefaultClusterfile()
-			clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
+			cf, err = clusterfile.NewClusterFile(nil)
 			if err != nil {
 				return err
 			}
-
-			cf, err = clusterfile.NewClusterFile(clusterFileData)
-			if err != nil {
-				return err
-			}
-
-			//store the Cluster as CfSnapshot for rollback
-			cf.CommitSnapshot()
 
 			cluster := cf.GetCluster()
 			if err = utils.ConstructClusterForScaleUp(&cluster, joinFlags, joinMasterIPList, joinNodeIPList); err != nil {
@@ -86,91 +74,17 @@ func NewJoinCmd() *cobra.Command {
 			}
 			cf.SetCluster(cluster)
 
-			//save desired clusterfile
-			if err = cf.SaveAll(); err != nil {
-				return err
-			}
-
-			defer func() {
-				if err == nil {
-					return
-				}
-				//if there exists an error,rollback the ClusterFile to the default file
-				cf.RollBackClusterFile()
-			}()
-
 			infraDriver, err := infradriver.NewInfraDriver(&cluster)
 			if err != nil {
 				return err
 			}
-
-			var (
-				clusterImageName = cluster.Spec.Image
-				newHosts         = append(joinMasterIPList, joinNodeIPList...)
-			)
 
 			imageEngine, err := imageengine.NewImageEngine(imagecommon.EngineGlobalConfigurations{})
 			if err != nil {
 				return err
 			}
 
-			clusterHostsPlatform, err := infraDriver.GetHostsPlatform(newHosts)
-			if err != nil {
-				return err
-			}
-
-			imageMounter, err := imagedistributor.NewImageMounter(imageEngine, clusterHostsPlatform)
-			if err != nil {
-				return err
-			}
-
-			imageMountInfo, err := imageMounter.Mount(clusterImageName)
-			if err != nil {
-				return err
-			}
-			defer func() {
-				if e := imageMounter.Umount(clusterImageName, imageMountInfo); e != nil {
-					logrus.Errorf("failed to umount cluster image: %v", e)
-				}
-			}()
-
-			distributor, err := imagedistributor.NewScpDistributor(imageMountInfo, infraDriver, cf.GetConfigs())
-			if err != nil {
-				return err
-			}
-
-			plugins, err := loadPluginsFromImage(imageMountInfo)
-			if err != nil {
-				return err
-			}
-
-			if cf.GetPlugins() != nil {
-				plugins = append(plugins, cf.GetPlugins()...)
-			}
-
-			runtimeConfig := &clusterruntime.RuntimeConfig{
-				Distributor: distributor,
-				Plugins:     plugins,
-			}
-
-			if cf.GetKubeadmConfig() != nil {
-				runtimeConfig.KubeadmConfig = *cf.GetKubeadmConfig()
-			}
-
-			installer, err := clusterruntime.NewInstaller(infraDriver, *runtimeConfig)
-			if err != nil {
-				return err
-			}
-			_, _, err = installer.ScaleUp(joinMasterIPList, joinNodeIPList)
-			if err != nil {
-				return err
-			}
-
-			if err = cf.SaveAll(); err != nil {
-				return err
-			}
-
-			return nil
+			return scaleUpCluster(cluster.Spec.Image, joinMasterIPList, joinNodeIPList, infraDriver, imageEngine, cf)
 		},
 	}
 

--- a/cmd/sealer/cmd/cluster/run-app.go
+++ b/cmd/sealer/cmd/cluster/run-app.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
@@ -46,18 +45,11 @@ func NewRunAPPCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				cf              clusterfile.Interface
-				clusterFileData []byte
-				err             error
+				cf  clusterfile.Interface
+				err error
 			)
 
-			//todo grab more cluster info from api server
-			clusterFileData, err = os.ReadFile(common.GetDefaultClusterfile())
-			if err != nil {
-				return err
-			}
-
-			cf, err = clusterfile.NewClusterFile(clusterFileData)
+			cf, err = clusterfile.NewClusterFile(nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -16,18 +16,26 @@ package clusterfile
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/sealerio/sealer/common"
+	"github.com/sealerio/sealer/pkg/client/k8s"
 	"github.com/sealerio/sealer/pkg/runtime/kubernetes/kubeadm"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
 	utilsos "github.com/sealerio/sealer/utils/os"
-	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	configMapNamespace = "kube-system"
+	configMapDataName  = "Clusterfile"
+	configMapName      = "sealer-clusterfile"
 )
 
 type Interface interface {
@@ -36,14 +44,16 @@ type Interface interface {
 	GetConfigs() []v1.Config
 	GetPlugins() []v1.Plugin
 	GetKubeadmConfig() *kubeadm.KubeadmConfig
-	CommitSnapshot()
-	SaveAll() error
-	RollBackClusterFile()
+	SaveAll(opts SaveOptions) error
+}
+
+type SaveOptions struct {
+	// if true ,will commit clusterfile to cluster
+	CommitToCluster bool
 }
 
 type ClusterFile struct {
 	cluster       *v2.Cluster
-	cfSnapshot    *v2.Cluster
 	configs       []v1.Config
 	kubeadmConfig kubeadm.KubeadmConfig
 	plugins       []v1.Plugin
@@ -69,12 +79,7 @@ func (c *ClusterFile) GetKubeadmConfig() *kubeadm.KubeadmConfig {
 	return &c.kubeadmConfig
 }
 
-func (c *ClusterFile) CommitSnapshot() {
-	c.cfSnapshot = new(v2.Cluster)
-	*c.cfSnapshot = *c.cluster
-}
-
-func (c *ClusterFile) SaveAll() error {
+func (c *ClusterFile) SaveAll(opts SaveOptions) error {
 	var (
 		clusterfileBytes [][]byte
 		config           []byte
@@ -150,27 +155,72 @@ func (c *ClusterFile) SaveAll() error {
 		}
 		clusterfileBytes = append(clusterfileBytes, kubeProxyConfiguration)
 	}
-	//todo cluster ssh info need to be encrypted
 
-	return utilsos.NewCommonWriter(fileName).WriteFile(bytes.Join(clusterfileBytes, []byte("---\n")))
+	content := bytes.Join(clusterfileBytes, []byte("---\n"))
+	err = utilsos.NewCommonWriter(fileName).WriteFile(content)
+	if err != nil {
+		return fmt.Errorf("failed to save clusterfile to disk:%v", err)
+	}
+
+	if opts.CommitToCluster {
+		return saveToCluster(content)
+	}
+	return nil
 }
 
-func (c *ClusterFile) RollBackClusterFile() {
-	if c.cfSnapshot == nil {
-		logrus.Errorf("cfSnapshot is nill, can not rollback")
-		return
+func saveToCluster(data []byte) error {
+	client, err := k8s.NewK8sClient()
+	if err != nil {
+		return err
 	}
-	*c.cluster = *c.cfSnapshot
-	if err := c.SaveAll(); err != nil {
-		logrus.Errorf("failed to rollback the ClusterFile to the default file: %v", err)
+
+	configMap := corev1.ConfigMap(configMapName, configMapNamespace)
+	configMap.Data = map[string]string{configMapDataName: string(data)}
+
+	_, err = client.ConfigMap(configMapNamespace).Apply(context.TODO(), configMap, metav1.ApplyOptions{FieldManager: "kubectl-create"})
+	if err != nil {
+		return fmt.Errorf("failed to create configmap: %v", err)
 	}
+	return nil
 }
 
 func NewClusterFile(b []byte) (Interface, error) {
 	clusterFile := new(ClusterFile)
-	if err := decodeClusterFile(bytes.NewReader(b), clusterFile); err != nil {
-		return nil, fmt.Errorf("failed to load clusterfile: %v", err)
+	// use user specified clusterfile
+	if len(b) > 0 {
+		if err := decodeClusterFile(bytes.NewReader(b), clusterFile); err != nil {
+			return nil, fmt.Errorf("failed to load clusterfile: %v", err)
+		}
+		return clusterFile, nil
 	}
 
+	// assume that we already have an existed cluster
+	client, _ := k8s.NewK8sClient()
+	if client != nil {
+		cm, err := client.ConfigMap(configMapNamespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		data := cm.Data[configMapDataName]
+		if len(data) > 0 {
+			err := decodeClusterFile(bytes.NewReader([]byte(data)), clusterFile)
+			if err != nil {
+				return nil, err
+			}
+			return clusterFile, nil
+		}
+	}
+
+	// read local disk clusterfile
+	workClusterfile := common.GetDefaultClusterfile()
+	clusterFileData, err := os.ReadFile(filepath.Clean(workClusterfile))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decodeClusterFile(bytes.NewReader(clusterFileData), clusterFile); err != nil {
+		return nil, fmt.Errorf("failed to load clusterfile: %v", err)
+	}
 	return clusterFile, nil
 }

--- a/pkg/clusterfile/clusterfile_test.go
+++ b/pkg/clusterfile/clusterfile_test.go
@@ -117,7 +117,7 @@ func TestSaveAll(t *testing.T) {
 			if err := os.MkdirAll(filepath.Dir(clusterFilePath), common.FileMode0755); err != nil {
 				t.Errorf("failed to create directory, error is:(%v)", err)
 			}
-			if err := clusterFile.SaveAll(); err != nil {
+			if err := clusterFile.SaveAll(SaveOptions{}); err != nil {
 				t.Errorf("failed to save all file, error is:(%v)", err)
 			}
 			clusterFileData, err := os.ReadFile(filepath.Clean(clusterFilePath))


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

at present , we store the cluster configuration information on the master0 local disk after we create the cluster, such as node auth info , cluster plugins, cluster env and so on .

If this file is mistakenly deleted or modified by mistake, it will be a great disaster for the maintenance of the cluster. 

so we need to store this file in the cluster to do disaster preparedness, and each time we can prioritized use the clusterfile  in the cluster for operation.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

1. save clusterfile to cluster as configmap with name "sealer-clusterfile"  in namespace "kub-system".
2. modify some cmd examples

### Describe how to verify it


### Special notes for reviews
