### PR TITLE
feat: support to add node labels via clusterfile

### DIFF
--- a/pkg/cluster-runtime/scale.go
+++ b/pkg/cluster-runtime/scale.go
@@ -102,6 +102,10 @@ func (i *Installer) ScaleUp(newMasters, newWorkers []net.IP) (registry.Driver, r
 		return nil, nil, err
 	}
 
+	if err := i.setNodeLabels(all, runtimeDriver); err != nil {
+		return nil, nil, err
+	}
+
 	return registryDriver, runtimeDriver, nil
 }
 

--- a/pkg/infradriver/infradriver.go
+++ b/pkg/infradriver/infradriver.go
@@ -33,6 +33,9 @@ type InfraDriver interface {
 	//GetHostEnv return merged env with host env and cluster env.
 	GetHostEnv(host net.IP) map[string]interface{}
 
+	//GetHostLabels return host labels.
+	GetHostLabels(host net.IP) map[string]string
+
 	//GetClusterEnv return cluster.spec.env as map[string]interface{}
 	GetClusterEnv() map[string]interface{}
 

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -54,7 +54,8 @@ type Host struct {
 	//overwrite SSH config
 	SSH v1.SSH `json:"ssh,omitempty"`
 	//overwrite env
-	Env []string `json:"env,omitempty"`
+	Env    []string          `json:"env,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

sometimes, user wants to specify the cluster node lables field according to their business scenario. So I thought we could support this feature by configuring the desired clusterfile.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it

we could set labels filed in clusterfile, this will add label content to each cluster node.

```yaml
apiVersion: sealer.cloud/v2
kind: Cluster
metadata:
  creationTimestamp: null
  name: my-cluster
spec:
  hosts:
  - ips:
    - 172.16.26.187
    roles:
    - node
    labels:
      foo: bar
    ssh: {}
  - ips:
    - 172.16.26.188
    roles:
    - master
    labels:
      fake: labels
    ssh: {}
  image: registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.22.4-test
  ssh:
    passwd: testabs
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
status: {}

```

### Special notes for reviews
