### PR TITLE
feat: add shell type for APP instruction

### DIFF
--- a/build/kubefile/parser/app_handler.go
+++ b/build/kubefile/parser/app_handler.go
@@ -20,12 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sealerio/sealer/pkg/define/application"
-
-	"github.com/sealerio/sealer/build/kubefile/command"
-
 	"github.com/pkg/errors"
-
+	"github.com/sealerio/sealer/build/kubefile/command"
 	v1 "github.com/sealerio/sealer/pkg/define/application/v1"
 )
 
@@ -99,24 +95,15 @@ func (kp *KubefileParser) processApp(node *Node, result *KubefileResult) error {
 	result.Dockerfile = mergeLines(result.Dockerfile, tmpLine)
 	result.legacyContext.apps2Files[appName] = append([]string{}, filesToCopy...)
 
-	isH, err := isHelm(filesToCopy...)
+	appType, launchFiles, err := getApplicationType(filesToCopy)
 	if err != nil {
 		return fmt.Errorf("error in judging the application type: %v", err)
-	}
-
-	appType := ""
-	switch isH {
-	case true:
-		appType = application.HelmApp
-	case false:
-		appType = application.KubeApp
-	default:
-		return errors.Errorf("error in identifying the type of app:%s", appName)
 	}
 
 	v1App := v1.NewV1Application(
 		appName,
 		appType,
+		launchFiles,
 	).(*v1.Application)
 
 	result.Applications[v1App.Name()] = v1App

--- a/build/kubefile/parser/image_engine_test.go
+++ b/build/kubefile/parser/image_engine_test.go
@@ -30,10 +30,12 @@ var testExtensionWithApp = v1.ImageExtension{
 		v12.NewV1Application(
 			"es",
 			"helm",
+			[]string{},
 		),
 		v12.NewV1Application(
 			"ts",
 			"kube",
+			[]string{},
 		),
 	},
 }

--- a/build/kubefile/parser/kubefile.go
+++ b/build/kubefile/parser/kubefile.go
@@ -184,6 +184,12 @@ func (kp *KubefileParser) processLaunch(node *Node, result *KubefileResult) erro
 			return fmt.Sprintf("kubectl apply -f %s", path), nil
 		case application.HelmApp:
 			return fmt.Sprintf("helm install %s %s", v1app.Name(), path), nil
+		case application.ShellApp:
+			var cmds []string
+			for _, file := range v1app.LaunchFiles() {
+				cmds = append(cmds, fmt.Sprintf("bash %s", filepath.Join(path, file)))
+			}
+			return strings.Join(cmds, " && "), nil
 		default:
 			return "", errors.Errorf("unexpected application type %s", v1app.Type())
 		}

--- a/build/kubefile/parser/parse_test.go
+++ b/build/kubefile/parser/parse_test.go
@@ -91,13 +91,15 @@ copy %s %s
 			app1Name: v1.NewV1Application(
 				app1Name,
 				application.KubeApp,
+				[]string{},
 			),
 		},
 	}
 
 	assert.Equal(t, expectedResult.Dockerfile, result.Dockerfile)
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
-	assert.Equal(t, expectedResult.Applications[app1Name], result.Applications[app1Name])
+	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
+	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
 	assert.Equal(t, expectedResult.LaunchList, result.LaunchList)
 }
 
@@ -154,13 +156,15 @@ copy %s %s
 			app1Name: v1.NewV1Application(
 				app1Name,
 				application.HelmApp,
+				[]string{},
 			),
 		},
 	}
 
 	assert.Equal(t, expectedResult.Dockerfile, result.Dockerfile)
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
-	assert.Equal(t, expectedResult.Applications[app1Name], result.Applications[app1Name])
+	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
+	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
 	assert.Equal(t, expectedResult.LaunchList, result.LaunchList)
 }
 

--- a/pkg/define/application/types.go
+++ b/pkg/define/application/types.go
@@ -15,6 +15,7 @@
 package application
 
 const (
-	KubeApp string = "kube"
-	HelmApp string = "helm"
+	KubeApp  string = "kube"
+	HelmApp  string = "helm"
+	ShellApp string = "shell"
 )

--- a/pkg/define/application/v1/application.go
+++ b/pkg/define/application/v1/application.go
@@ -19,9 +19,10 @@ import (
 )
 
 type Application struct {
-	NameVar    string `json:"name"`
-	TypeVar    string `json:"type,omitempty"`
-	VersionVar string `json:"version,omitempty"`
+	NameVar        string   `json:"name"`
+	TypeVar        string   `json:"type,omitempty"`
+	LaunchFilesVar []string `json:"launchfiles,omitempty"`
+	VersionVar     string   `json:"version,omitempty"`
 }
 
 func (app *Application) Version() string {
@@ -36,12 +37,17 @@ func (app *Application) Type() string {
 	return app.TypeVar
 }
 
+func (app *Application) LaunchFiles() []string {
+	return app.LaunchFilesVar
+}
+
 func NewV1Application(
 	name string,
-	appType string) version.VersionedApplication {
+	appType string, launchFiles []string) version.VersionedApplication {
 	return &Application{
-		NameVar:    name,
-		TypeVar:    appType,
-		VersionVar: "v1",
+		NameVar:        name,
+		TypeVar:        appType,
+		LaunchFilesVar: launchFiles,
+		VersionVar:     "v1",
 	}
 }

--- a/pkg/define/application/version/version.go
+++ b/pkg/define/application/version/version.go
@@ -21,4 +21,6 @@ type VersionedApplication interface {
 	Name() string
 
 	Type() string
+
+	LaunchFiles() []string
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

sometimes when installing an app type cluster image, we need to configure some additional information. such as some k8s  cluster resources which cannot be directly written in the yaml file as fixed value.

if so, we nee add shell type for APP instruction, and  it does not affect the current usage.

for shell :
1. if local file is normal file and the suffix of this file ends with a ".sh", will copy it to rootfs ,and write its launch cmd in  sealer image extension at build stage.
2.  if local file is dir,   will walk though the target dir , and  collect all files which suffix is ends with a ".sh", then write its launch cmd in sealer image extension at build stage.

below is my test kubefile:

```shell
FROM scratch
APP config local://config.sh
APP my-shell local://shell 
APP dashboard local://dashboard.yaml
LAUNCH ["config","my-shell","dashboard"]
```
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
