### PR TITLE
fix: duplicate download container images that already exist in base image

### DIFF
--- a/pkg/image/save/filesystem.go
+++ b/pkg/image/save/filesystem.go
@@ -248,7 +248,7 @@ func (d *driver) Stat(ctx context.Context, subPath string) (storagedriver.FileIn
 func (d *driver) List(ctx context.Context, subPath string) ([]string, error) {
 	fullPath := d.fullPath(subPath)
 	// #nosec
-	dir, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE, 0600)
+	dir, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, storagedriver.PathNotFoundError{Path: subPath}

--- a/pkg/image/save/utils.go
+++ b/pkg/image/save/utils.go
@@ -42,6 +42,17 @@ type Named struct {
 	tag    string //eg. latest
 }
 
+func (n Named) String() string {
+	return n.Name()
+}
+
+func (n Named) Name() string {
+	if n.domain == "" {
+		return n.Repo()
+	}
+	return n.domain + "/" + n.Repo()
+}
+
 func (n Named) FullName() string {
 	return n.domain + "/" + n.repo + ":" + n.tag
 }


### PR DESCRIPTION

Signed-off-by: Lancelot <1984737645@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?
#1881 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

I use a way to find the Docker image locally whether the image has already existed in Base Image

### Describe how to verify it
Before
![image](https://user-images.githubusercontent.com/53330071/205493839-eee30e89-c997-48bc-b34c-c26dbe63fcc5.png)

We don't need to download again
![image](https://user-images.githubusercontent.com/53330071/205494009-621514a5-29fb-48df-83cf-a0da9ed03107.png)



### Special notes for reviews
