### PR TITLE
support launch app via its name though clusterfile or cli

### DIFF
--- a/build/kubefile/parser/app_handler.go
+++ b/build/kubefile/parser/app_handler.go
@@ -94,7 +94,6 @@ func (kp *KubefileParser) processApp(node *Node, result *KubefileResult) error {
 	tmpLine := strings.Join(append([]string{command.Copy}, append(filesToCopy, destDir)...), " ")
 	result.Dockerfile = mergeLines(result.Dockerfile, tmpLine)
 	result.legacyContext.apps2Files[appName] = append([]string{}, filesToCopy...)
-
 	appType, launchFiles, err := getApplicationType(filesToCopy)
 	if err != nil {
 		return fmt.Errorf("error in judging the application type: %v", err)
@@ -105,7 +104,6 @@ func (kp *KubefileParser) processApp(node *Node, result *KubefileResult) error {
 		appType,
 		launchFiles,
 	).(*v1.Application)
-
 	result.Applications[v1App.Name()] = v1App
 	return nil
 }

--- a/build/kubefile/parser/parse_test.go
+++ b/build/kubefile/parser/parse_test.go
@@ -34,7 +34,6 @@ import (
 
 const (
 //nginxDemoURL = "https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/application/deployment.yaml"
-
 )
 
 var testParser *KubefileParser
@@ -63,7 +62,8 @@ func TestParserKubeApp(t *testing.T) {
 		text     = fmt.Sprintf(`
 FROM busybox as base
 APP %s local://%s
-`, app1Name, nginxDemoPath)
+LAUNCH ["%s"]
+`, app1Name, nginxDemoPath, app1Name)
 	)
 
 	reader := bytes.NewReader([]byte(text))
@@ -86,12 +86,12 @@ copy %s %s
 	result.Dockerfile = strings.TrimSpace(result.Dockerfile)
 	expectedResult := &KubefileResult{
 		Dockerfile: strings.TrimSpace(expectedText),
-		LaunchList: []string{},
+		AppNames:   []string{app1Name},
 		Applications: map[string]version.VersionedApplication{
 			app1Name: v1.NewV1Application(
 				app1Name,
 				application.KubeApp,
-				[]string{},
+				[]string{nginxDemoPath},
 			),
 		},
 	}
@@ -100,7 +100,7 @@ copy %s %s
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
 	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
 	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
-	assert.Equal(t, expectedResult.LaunchList, result.LaunchList)
+	assert.Equal(t, expectedResult.AppNames, result.AppNames)
 }
 
 func TestParserHelmApp(t *testing.T) {
@@ -149,14 +149,12 @@ copy %s %s
 	result.Dockerfile = strings.TrimSpace(result.Dockerfile)
 	expectedResult := &KubefileResult{
 		Dockerfile: strings.TrimSpace(expectedText),
-		LaunchList: []string{
-			fmt.Sprintf("helm install %s %s", app1Name, app1Path),
-		},
+		AppNames:   []string{app1Name},
 		Applications: map[string]version.VersionedApplication{
 			app1Name: v1.NewV1Application(
 				app1Name,
 				application.HelmApp,
-				[]string{},
+				[]string{githubAppPath},
 			),
 		},
 	}
@@ -165,7 +163,7 @@ copy %s %s
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
 	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
 	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
-	assert.Equal(t, expectedResult.LaunchList, result.LaunchList)
+	assert.Equal(t, expectedResult.AppNames, result.AppNames)
 }
 
 func TestParserCMDS(t *testing.T) {
@@ -206,7 +204,7 @@ FROM busybox as base
 	result.Dockerfile = strings.TrimSpace(result.Dockerfile)
 	expectedResult := &KubefileResult{
 		Dockerfile: strings.TrimSpace(expectedText),
-		LaunchList: []string{
+		RawCmds: []string{
 			"kubectl apply -f abc.yaml",
 			"kubectl apply -f bcd.yaml",
 		},
@@ -215,7 +213,7 @@ FROM busybox as base
 
 	assert.Equal(t, expectedResult.Dockerfile, result.Dockerfile)
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
-	assert.Equal(t, expectedResult.LaunchList, result.LaunchList)
+	assert.Equal(t, expectedResult.RawCmds, result.RawCmds)
 }
 
 func setupTempContext() (string, error) {

--- a/build/kubefile/parser/utils.go
+++ b/build/kubefile/parser/utils.go
@@ -220,7 +220,7 @@ func isShell(sources ...string) (bool, []string, error) {
 func getApplicationType(sources []string) (string, []string, error) {
 	isy, yamlErr := isYaml(sources...)
 	if isy {
-		return application.KubeApp, nil, nil
+		return application.KubeApp, sources, nil
 	}
 
 	iss, files, shellErr := isShell(sources...)
@@ -230,7 +230,7 @@ func getApplicationType(sources []string) (string, []string, error) {
 
 	ish, helmErr := isHelm(sources...)
 	if ish {
-		return application.HelmApp, nil, nil
+		return application.HelmApp, sources, nil
 	}
 
 	if yamlErr != nil {

--- a/cmd/sealer/cmd/cluster/apply.go
+++ b/cmd/sealer/cmd/cluster/apply.go
@@ -104,7 +104,9 @@ func NewApplyCmd() *cobra.Command {
 
 			if extension.Type == v12.AppInstaller {
 				logrus.Infof("start to install application: %s", imageName)
-				return installApplication(imageName, nil, extension, infraDriver, imageEngine, applyMode)
+				cmds := infraDriver.GetClusterLaunchCmds()
+				apps := infraDriver.GetClusterLaunchApps()
+				return installApplication(imageName, cmds, apps, extension, infraDriver, imageEngine, applyMode)
 			}
 
 			client := utils.GetClusterClient()

--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -108,10 +108,10 @@ func NewRunCmd() *cobra.Command {
 				}); err != nil {
 					return err
 				}
-				return installApplication(args[0], runFlags.LaunchCmds, extension, infraDriver, imageEngine, applyMode)
+				return installApplication(args[0],  runFlags.Cmds, runFlags.AppNames, extension, infraDriver, imageEngine, applyMode)
 			}
 
-			if len(runFlags.LaunchCmds) > 0 {
+			if len(runFlags.Cmds) > 0 {
 				return fmt.Errorf("this command parameter (--cmds) is only available to application images")
 			}
 
@@ -173,8 +173,8 @@ func NewRunCmd() *cobra.Command {
 	runCmd.Flags().Uint16Var(&runFlags.Port, "port", 22, "set the sshd service port number for the server (default port: 22)")
 	runCmd.Flags().StringVar(&runFlags.Pk, "pk", filepath.Join(common.GetHomeDir(), ".ssh", "id_rsa"), "set baremetal server private key")
 	runCmd.Flags().StringVar(&runFlags.PkPassword, "pk-passwd", "", "set baremetal server private key password")
-	runCmd.Flags().StringSliceVar(&runFlags.CMDArgs, "cmd-args", []string{}, "set args for image cmd instruction")
-	runCmd.Flags().StringSliceVar(&runFlags.LaunchCmds, "cmds", []string{}, "override default LaunchCmds of clusterimage")
+	runCmd.Flags().StringSliceVar(&runFlags.Cmds, "cmds", []string{}, "override default LaunchCmds of clusterimage")
+	runCmd.Flags().StringSliceVar(&runFlags.AppNames, "apps", []string{}, "override default AppNames of clusterimage")
 	runCmd.Flags().StringSliceVarP(&runFlags.CustomEnv, "env", "e", []string{}, "set custom environment variables")
 	runCmd.Flags().StringVarP(&runFlags.ClusterFile, "Clusterfile", "f", "", "Clusterfile path to run a Kubernetes cluster")
 	runCmd.Flags().StringVar(&runFlags.Mode, "mode", common.ApplyModeApply, "load images to the specified registry in advance")
@@ -309,8 +309,19 @@ func loadToRegistry(infraDriver infradriver.InfraDriver, distributor imagedistri
 	return nil
 }
 
-func installApplication(appImageName string, launchCmds []string, extension v12.ImageExtension,
+func installApplication(appImageName string, cmds []string, appNames []string, extension v12.ImageExtension,
 	infraDriver infradriver.InfraDriver, imageEngine imageengine.Interface, mode string) error {
+	if len(cmds) != 0 && len(appNames) != 0 {
+		return fmt.Errorf("only one can be selected to do overwrite for launchCmds(%s) and appNames（%s）", cmds, appNames)
+	}
+
+	var launchCmds []string
+	if len(cmds) != 0 {
+		launchCmds = cmds
+	} else {
+		launchCmds = clusterruntime.GetAppLaunchCmdsByNames(appNames, extension.Applications)
+	}
+
 	clusterHosts := infraDriver.GetHostIPList()
 
 	clusterHostsPlatform, err := infraDriver.GetHostsPlatform(clusterHosts)

--- a/cmd/sealer/cmd/image/build.go
+++ b/cmd/sealer/cmd/image/build.go
@@ -344,7 +344,8 @@ func buildImageExtensionOnResult(result *parser.KubefileResult, imageType string
 	for _, app := range result.Applications {
 		extension.Applications = append(extension.Applications, app)
 	}
-	extension.Launch.Cmds = result.LaunchList
+	extension.Launch.Cmds = result.RawCmds
+	extension.Launch.AppNames = result.AppNames
 	return extension
 }
 

--- a/cmd/sealer/cmd/types/types.go
+++ b/cmd/sealer/cmd/types/types.go
@@ -30,10 +30,12 @@ type Flags struct {
 	CMDArgs     []string
 	Mode        string
 	ClusterFile string
-	// override default LaunchCmds of clusterimage
-	LaunchCmds []string
-	// maybe we can support to override default LaunchArgs of clusterimage to render LaunchCmds.
-	LaunchArgs []string
+
+	// override default Cmds of clusterimage
+	Cmds []string
+	// override default APPNames of clusterimage
+	// Only one can be selected for LaunchCmds and AppNames
+	AppNames []string
 }
 
 type ApplyFlags struct {

--- a/pkg/cluster-runtime/apps.go
+++ b/pkg/cluster-runtime/apps.go
@@ -20,17 +20,21 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sealerio/sealer/pkg/rootfs"
 
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/sealerio/sealer/common"
 	containerruntime "github.com/sealerio/sealer/pkg/container-runtime"
+	v1 "github.com/sealerio/sealer/pkg/define/application/v1"
+	"github.com/sealerio/sealer/pkg/define/application/version"
 	v12 "github.com/sealerio/sealer/pkg/define/image/v1"
 	"github.com/sealerio/sealer/pkg/imagedistributor"
 	"github.com/sealerio/sealer/pkg/infradriver"
 	"github.com/sealerio/sealer/pkg/registry"
+	"github.com/sirupsen/logrus"
 )
 
 type AppInstaller struct {
@@ -87,15 +91,15 @@ func (i *AppInstaller) Install(master0 net.IP, cmds []string) error {
 
 func (i AppInstaller) LaunchClusterImage(master0 net.IP, launchCmds []string) error {
 	var (
-		cmds    []string
-		appPath = i.infraDriver.GetClusterRootfsPath()
-		ex      = shell.NewLex('\\')
+		cmds       []string
+		rootfsPath = i.infraDriver.GetClusterRootfsPath()
+		ex         = shell.NewLex('\\')
 	)
 
 	if len(launchCmds) > 0 {
 		cmds = launchCmds
 	} else {
-		cmds = i.extension.Launch.Cmds
+		cmds = GetImageDefaultLaunchCmds(i.extension)
 	}
 
 	for _, value := range cmds {
@@ -107,7 +111,7 @@ func (i AppInstaller) LaunchClusterImage(master0 net.IP, launchCmds []string) er
 			return fmt.Errorf("failed to render launch cmd: %v", err)
 		}
 
-		if err = i.infraDriver.CmdAsync(master0, fmt.Sprintf(common.CdAndExecCmd, appPath, cmdline)); err != nil {
+		if err = i.infraDriver.CmdAsync(master0, fmt.Sprintf(common.CdAndExecCmd, rootfsPath, cmdline)); err != nil {
 			return err
 		}
 	}
@@ -146,4 +150,38 @@ func (i AppInstaller) save(applicationFile string) error {
 	}
 
 	return nil
+}
+
+func GetImageDefaultLaunchCmds(extension v12.ImageExtension) []string {
+	appNames := extension.Launch.AppNames
+	launchCmds := GetAppLaunchCmdsByNames(appNames, extension.Applications)
+
+	// if app name exist in extension, return it`s launch cmds firstly.
+	if len(launchCmds) != 0 {
+		return launchCmds
+	}
+
+	return extension.Launch.Cmds
+}
+
+func GetAppLaunchCmdsByNames(appNames []string, apps []version.VersionedApplication) []string {
+	var appCmds []string
+	for _, name := range appNames {
+		appRoot := makeItDir(filepath.Join(rootfs.GlobalManager.App().Root(), name))
+		for _, app := range apps {
+			v1app := app.(*v1.Application)
+			if v1app.Name() != name {
+				continue
+			}
+			appCmds = append(appCmds, v1app.LaunchCmd(appRoot))
+		}
+	}
+	return appCmds
+}
+
+func makeItDir(str string) string {
+	if !strings.HasSuffix(str, "/") {
+		return str + "/"
+	}
+	return str
 }

--- a/pkg/define/application/v1/application.go
+++ b/pkg/define/application/v1/application.go
@@ -15,6 +15,11 @@
 package v1
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sealerio/sealer/pkg/define/application"
 	"github.com/sealerio/sealer/pkg/define/application/version"
 )
 
@@ -37,8 +42,21 @@ func (app *Application) Type() string {
 	return app.TypeVar
 }
 
-func (app *Application) LaunchFiles() []string {
-	return app.LaunchFilesVar
+func (app *Application) LaunchCmd(appRoot string) string {
+	switch app.Type() {
+	case application.KubeApp:
+		return fmt.Sprintf("kubectl apply -f %s", appRoot)
+	case application.HelmApp:
+		return fmt.Sprintf("helm install %s %s", app.Name(), appRoot)
+	case application.ShellApp:
+		var cmds []string
+		for _, file := range app.LaunchFilesVar {
+			cmds = append(cmds, fmt.Sprintf("bash %s", filepath.Join(appRoot, file)))
+		}
+		return strings.Join(cmds, " && ")
+	default:
+		return ""
+	}
 }
 
 func NewV1Application(

--- a/pkg/define/application/version/version.go
+++ b/pkg/define/application/version/version.go
@@ -14,7 +14,7 @@
 
 package version
 
-// TODO maybe move it a global version interface, for version compatibility
+// VersionedApplication TODO maybe move it a global version interface, for version compatibility
 type VersionedApplication interface {
 	Version() string
 
@@ -22,5 +22,5 @@ type VersionedApplication interface {
 
 	Type() string
 
-	LaunchFiles() []string
+	LaunchCmd(appRoot string) string
 }

--- a/pkg/infradriver/infradriver.go
+++ b/pkg/infradriver/infradriver.go
@@ -53,6 +53,9 @@ type InfraDriver interface {
 	//GetClusterLaunchCmds ${user-defined launch command}
 	GetClusterLaunchCmds() []string
 
+	//GetClusterLaunchApps ${user-defined launch apps}
+	GetClusterLaunchApps() []string
+
 	//GetClusterRootfsPath /var/lib/sealer/data/${clusterName}/rootfs
 	GetClusterRootfsPath() string
 

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -45,6 +45,7 @@ type SSHInfraDriver struct {
 	clusterName           string
 	clusterImageName      string
 	clusterLaunchCmds     []string
+	clusterLaunchApps     []string
 	clusterHostAliases    []v2.HostAlias
 	clusterRegistryConfig v2.Registry
 }
@@ -118,6 +119,7 @@ func NewInfraDriver(cluster *v2.Cluster) (InfraDriver, error) {
 		clusterName:       cluster.Name,
 		clusterImageName:  cluster.Spec.Image,
 		clusterLaunchCmds: cluster.Spec.CMD,
+		clusterLaunchApps: cluster.Spec.APPNames,
 		sshConfigs:        map[string]ssh.Interface{},
 		roleHostsMap:      map[string][]net.IP{},
 		// todo need to separate env into app render data and sys render data
@@ -400,6 +402,10 @@ func (d *SSHInfraDriver) GetClusterImageName() string {
 
 func (d *SSHInfraDriver) GetClusterLaunchCmds() []string {
 	return d.clusterLaunchCmds
+}
+
+func (d *SSHInfraDriver) GetClusterLaunchApps() []string {
+	return d.clusterLaunchApps
 }
 
 func (d *SSHInfraDriver) GetHostName(hostIP net.IP) (string, error) {

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -39,8 +39,10 @@ type ClusterSpec struct {
 	Env     []string `json:"env,omitempty"`
 	CMDArgs []string `json:"cmd_args,omitempty"`
 	CMD     []string `json:"cmd,omitempty"`
-	Hosts   []Host   `json:"hosts,omitempty"`
-	SSH     v1.SSH   `json:"ssh,omitempty"`
+	// APPNames This field allows user to specify the app name they want to run launch.
+	APPNames []string `json:"appNames,omitempty"`
+	Hosts    []Host   `json:"hosts,omitempty"`
+	SSH      v1.SSH   `json:"ssh,omitempty"`
 	// HostAliases holds the mapping between IP and hostnames that will be injected as an entry in the
 	// host's hosts file.
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
sealer store some basic information about the cluster image in the image's annotations, such as cluster image type, applications list and its launch commands in one field .

however, we cannot accurately find the application launch command based on its name and all launch commands generate from "APP" instruction is mixed with the "CMDS" instruction in "launch.cmds" filed .

Therefore, I recommend that we only save the relevant information of the application during the build stage and control the launch logic of the application image during the run stage.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it

```yaml
apiVersion: sealer.cloud/v2
kind: Cluster
metadata:
  creationTimestamp: null
  name: my-cluster
spec:
  appNames: [ "nginx","mysql"]
  hosts:
  - ips:
    - 172.16.26.162
    roles:
    - master
    ssh: {}
  image: registry.cn-qingdao.aliyuncs.com/sealer-io/kubernetes:v1.22.15
  registry: {}
  ssh:
    passwd: Seadent123
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
status: {}
```

### Special notes for reviews
