### PR TITLE
support specify appname for config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,14 +22,13 @@ import (
 	"strings"
 
 	"github.com/imdario/mergo"
-
+	"github.com/sealerio/sealer/pkg/rootfs"
+	v1 "github.com/sealerio/sealer/types/api/v1"
+	"github.com/sealerio/sealer/utils/os"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	k8sv1 "k8s.io/api/core/v1"
 	k8sYaml "sigs.k8s.io/yaml"
-
-	v1 "github.com/sealerio/sealer/types/api/v1"
-	"github.com/sealerio/sealer/utils/os"
 )
 
 const (
@@ -71,8 +70,14 @@ func (c *Dumper) WriteFiles(configs []v1.Config) error {
 		if err := NewProcessorsAndRun(&config); err != nil {
 			return err
 		}
+
 		configData := []byte(config.Spec.Data)
-		configPath := filepath.Join(c.rootPath, config.Spec.Path)
+		path := config.Spec.Path
+		if config.Spec.APPName != "" {
+			path = filepath.Join(rootfs.GlobalManager.App().Root(), config.Spec.APPName, path)
+		}
+		configPath := filepath.Join(c.rootPath, path)
+
 		if !os.IsFileExist(configPath) {
 			err := os.NewCommonWriter(configPath).WriteFile(configData)
 			if err != nil {

--- a/types/api/v1/config_types.go
+++ b/types/api/v1/config_types.go
@@ -66,10 +66,20 @@ import (
 
 // ConfigSpec defines the desired state of Config
 type ConfigSpec struct {
+	// Enumeration value is "merge" and "overwrite". default value is "overwrite".
+	// Only yaml files format are supported if strategy is "merge", this will deeply merge each yaml file section.
+	// Otherwise, will overwrite the whole file content with config data.
 	Strategy string `json:"strategy,omitempty"`
-	Process  string `json:"process,omitempty"`
-	Data     string `json:"data,omitempty"`
-	Path     string `json:"path,omitempty"`
+	// preprocess with processor: value|toJson|toBase64|toSecret
+	Process string `json:"process,omitempty"`
+	//Data config real data
+	Data string `json:"data,omitempty"`
+	// which app to use this config.
+	APPName string `json:"appName,omitempty"`
+	// where the Data write on,
+	// it could be the relative path of rootfs (manifests/mysql.yaml).
+	// Or work with APPName to form a complete relative path(application/apps/{APPName}/mysql.yaml)
+	Path string `json:"path,omitempty"`
 }
 
 // ConfigStatus defines the observed state of Config


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

`ConfigSpec.path` is where the `ConfigSpec.Data` write on, it could be the relative path of rootfs (manifests/mysql.yaml). Or work with APPName to form a complete relative path(application/apps/{APPName}/mysql.yaml)



### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
