### PR TITLE
chore: add container image list for image spec

### DIFF
--- a/pkg/define/image/v1/sealer_image_extension.go
+++ b/pkg/define/image/v1/sealer_image_extension.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
-	SealerImageExtension = "sealer.image.extension"
+	SealerImageExtension          = "sealer.image.extension"
+	SealerImageContainerImageList = "sealer.image.container.images"
+
 	// Kube image type
 	KubeInstaller = "kube-installer"
 	AppInstaller  = "app-installer"
@@ -49,6 +51,23 @@ type ImageSpec struct {
 	OCIv1 ociv1.Image `json:"ociv1"`
 
 	ImageExtension
+
+	// ContainerImageList the container image list contained in the sealer image
+	//
+	// TODO: populate this value during the build phase
+	ContainerImageList []*ContainerImage `json:"containerImageList,omitempty"`
+}
+
+type ContainerImage struct {
+	// Image the container image name
+	Image string `json:"image" yaml:"image"`
+
+	// AppName the mame of the app to which the container image belongs
+	//
+	// NOTE: A container image may not belong to any app. In this case, the appName value is null.
+	AppName string `json:"appName,omitempty" yaml:"appName"`
+
+	// TODO: add more info about container image if necessary such as resourceKind, resourceName, etc.
 }
 
 // NOTE: the UnmarshalJSON function of ImageExtension has been overrode

--- a/pkg/imageengine/buildah/inspect.go
+++ b/pkg/imageengine/buildah/inspect.go
@@ -69,14 +69,19 @@ func (engine *Engine) Inspect(opts *options.InspectOptions) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get %s in image %s", image_v1.SealerImageExtension, opts.ImageNameOrID)
 	}
+	containerImageList, err := GetContainerImagesFromAnnotations(builderInfo.ImageAnnotations)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get %s in image %s", image_v1.SealerImageContainerImageList, opts.ImageNameOrID)
+	}
 
 	result := &image_v1.ImageSpec{
-		ID:             builderInfo.FromImageID,
-		Name:           builderInfo.FromImage,
-		Digest:         builderInfo.FromImageDigest,
-		ManifestV1:     manifest,
-		OCIv1:          builderInfo.OCIv1,
-		ImageExtension: imageExtension,
+		ID:                 builderInfo.FromImageID,
+		Name:               builderInfo.FromImage,
+		Digest:             builderInfo.FromImageDigest,
+		ManifestV1:         manifest,
+		OCIv1:              builderInfo.OCIv1,
+		ImageExtension:     imageExtension,
+		ContainerImageList: containerImageList,
 	}
 	if opts.Format != "" {
 		format := opts.Format

--- a/pkg/imageengine/buildah/sealer_image_extension.go
+++ b/pkg/imageengine/buildah/sealer_image_extension.go
@@ -46,7 +46,20 @@ func GetImageExtensionFromAnnotations(annotations map[string]string) (image_v1.I
 	}
 
 	if err := json.Unmarshal([]byte(extensionStr), &extension); err != nil {
-		return extension, fmt.Errorf("failed to unmarshal %v: %v", image_v1.SealerImageExtension, err)
+		return extension, errors.Wrapf(err, "failed to unmarshal %v", image_v1.SealerImageExtension)
 	}
 	return extension, nil
+}
+
+func GetContainerImagesFromAnnotations(annotations map[string]string) ([]*image_v1.ContainerImage, error) {
+	var containerImageList []*image_v1.ContainerImage
+	annotationStr := annotations[image_v1.SealerImageContainerImageList]
+	if len(annotationStr) == 0 {
+		return nil, nil
+	}
+
+	if err := json.Unmarshal([]byte(annotationStr), &containerImageList); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal %v", image_v1.SealerImageContainerImageList)
+	}
+	return containerImageList, nil
 }

--- a/pkg/imageengine/buildah/sealer_image_extension_test.go
+++ b/pkg/imageengine/buildah/sealer_image_extension_test.go
@@ -70,3 +70,68 @@ func TestGetImageExtensionFromAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestGetContainerImagesFromAnnotations(t *testing.T) {
+	type args struct {
+		annotations map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*image_v1.ContainerImage
+		wantErr bool
+	}{
+		{
+			name: "",
+			args: args{
+				annotations: map[string]string{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "",
+			args: args{
+				annotations: map[string]string{
+					image_v1.SealerImageContainerImageList: ``,
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "",
+			args: args{
+				annotations: map[string]string{
+					image_v1.SealerImageContainerImageList: `[{"image":"nginx:latest","appName":"nginx"},{"image":"registry.cn-qingdao.aliyuncs.com/sealer-io/dashboard:latest","appName":"dashboard"},{"image":"busybox:latest"}]`,
+				},
+			},
+			want: []*image_v1.ContainerImage{
+				{
+					Image:   "nginx:latest",
+					AppName: "nginx",
+				},
+				{
+					Image:   "registry.cn-qingdao.aliyuncs.com/sealer-io/dashboard:latest",
+					AppName: "dashboard",
+				},
+				{
+					Image: "busybox:latest",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetContainerImagesFromAnnotations(tt.args.annotations)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetContainerImagesFromAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetContainerImagesFromAnnotations() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: yuxing.lyx <yuxing.lyx@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add container image list for sealer image spec

the end users can get container image list by `sealer inspect` and the developer can get the container image list by  the key `sealer.image.container.images` from image annotations


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
after that, we also need to do the following:
1. parse and store the container image list when the build phase
2. add a flag for `sealer inspect` to decide whether to output the list of images because of container image list could be a huge number
