### PR TITLE
add getImageLabels func, to get CRI and cluster runtime info.

### DIFF
--- a/build/kubefile/parser/image_engine_test.go
+++ b/build/kubefile/parser/image_engine_test.go
@@ -150,6 +150,10 @@ func (testImageEngine) GetSealerImageExtension(opts *options.GetImageAnnoOptions
 	return testExtensionWithApp, nil
 }
 
+func (e testImageEngine) GetImageLabels(opts *options.GetImageLabelsOptions) (map[string]string, error) {
+	panic("implement me")
+}
+
 func (testImageEngine) LookupManifest(name string) (*libimage.ManifestList, error) {
 	panic("implement me")
 }

--- a/pkg/define/options/options.go
+++ b/pkg/define/options/options.go
@@ -155,6 +155,10 @@ type GetImageAnnoOptions struct {
 	ImageNameOrID string
 }
 
+type GetImageLabelsOptions struct {
+	ImageNameOrID string
+}
+
 type EngineGlobalConfigurations struct {
 	AuthFile  string
 	GraphRoot string

--- a/pkg/imageengine/buildah/get_image_info.go
+++ b/pkg/imageengine/buildah/get_image_info.go
@@ -39,3 +39,21 @@ func (engine *Engine) GetImageAnnotation(opts *options.GetImageAnnoOptions) (map
 	out := buildah.GetBuildInfo(builder)
 	return out.ImageAnnotations, nil
 }
+
+func (engine *Engine) GetImageLabels(opts *options.GetImageLabelsOptions) (map[string]string, error) {
+	if len(opts.ImageNameOrID) == 0 {
+		return nil, errors.New("image name id or image name should be specified")
+	}
+
+	ctx := getContext()
+	store := engine.ImageStore()
+	name := opts.ImageNameOrID
+
+	builder, err := openImage(ctx, engine.SystemContext(), store, name)
+	if err != nil {
+		return nil, err
+	}
+
+	out := buildah.GetBuildInfo(builder)
+	return out.OCIv1.Config.Labels, nil
+}

--- a/pkg/imageengine/interface.go
+++ b/pkg/imageengine/interface.go
@@ -63,6 +63,8 @@ type Interface interface {
 
 	GetSealerImageExtension(opts *options.GetImageAnnoOptions) (v1.ImageExtension, error)
 
+	GetImageLabels(opts *options.GetImageLabelsOptions) (map[string]string, error)
+
 	LookupManifest(name string) (*libimage.ManifestList, error)
 
 	CreateManifest(name string, opts *options.ManifestCreateOpts) error


### PR DESCRIPTION
Signed-off-by: starComingup <1225067236@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
We need to use image labels when we install different CRI、CSI、CNI and so on, so we need to get image labels info to help us understand which were specified by clusterimage.

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
If I did this correctly. I will use this function in sealer run.go.