### PR TITLE
support ${arch}

### DIFF
--- a/build/kubefile/parser/line_parsers.go
+++ b/build/kubefile/parser/line_parsers.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
@@ -35,6 +37,7 @@ var (
 
 const (
 	commandLabel = "LABEL"
+	ArchReg      = "${ARCH}"
 )
 
 // ignore the current argument. This will still leave a command parsed, but
@@ -304,6 +307,7 @@ func parseString(rest string, d *Directive) (*Node, map[string]bool, error) {
 //
 //nolint:unparam
 func parseJSON(rest string, d *Directive) (*Node, map[string]bool, error) {
+	rest = strings.Replace(rest, ArchReg, v1.Platform{}.Architecture, -1)
 	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
 	if !strings.HasPrefix(rest, "[") {
 		return nil, nil, fmt.Errorf(`error parsing "%s" as a JSON array`, rest)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
support ${ARCH}
example:

Kubefile:

```yaml
FROM scratch
COPY rootfs .
COPY ${ARCH}/* .
COPY imageList manifests
LABEL "cluster.alpha.sealer.io/cluster-runtime-version"="v1.22.15"
LABEL "cluster.alpha.sealer.io/cluster-runtime-type"="kubernetes"
LABEL "cluster.alpha.sealer.io/container-runtime-type"="docker"
LABEL "cluster.alpha.sealer.io/container-runtime-version"="19.03.14"
CNI calico local://tigera-operator.yaml local://custom-resources.yaml
LAUNCH ["calico"]
```


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
