### PR TITLE
support mixed app type with appcmds

### DIFF
--- a/build/kubefile/parser/parse_test.go
+++ b/build/kubefile/parser/parse_test.go
@@ -82,8 +82,8 @@ copy %s %s
 
 	result.Dockerfile = strings.TrimSpace(result.Dockerfile)
 	expectedResult := &KubefileResult{
-		Dockerfile: strings.TrimSpace(expectedText),
-		AppNames:   []string{app1Name},
+		Dockerfile:       strings.TrimSpace(expectedText),
+		LaunchedAppNames: []string{app1Name},
 		Applications: map[string]version.VersionedApplication{
 			app1Name: v1.NewV1Application(
 				app1Name,
@@ -97,7 +97,7 @@ copy %s %s
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
 	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
 	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
-	assert.Equal(t, expectedResult.AppNames, result.AppNames)
+	assert.Equal(t, expectedResult.LaunchedAppNames, result.LaunchedAppNames)
 }
 
 func TestParserHelmApp(t *testing.T) {
@@ -145,8 +145,8 @@ copy %s %s
 
 	result.Dockerfile = strings.TrimSpace(result.Dockerfile)
 	expectedResult := &KubefileResult{
-		Dockerfile: strings.TrimSpace(expectedText),
-		AppNames:   []string{app1Name},
+		Dockerfile:       strings.TrimSpace(expectedText),
+		LaunchedAppNames: []string{app1Name},
 		Applications: map[string]version.VersionedApplication{
 			app1Name: v1.NewV1Application(
 				app1Name,
@@ -160,7 +160,7 @@ copy %s %s
 	assert.Equal(t, len(expectedResult.Applications), len(result.Applications))
 	assert.Equal(t, expectedResult.Applications[app1Name].Name(), result.Applications[app1Name].Name())
 	assert.Equal(t, expectedResult.Applications[app1Name].Type(), result.Applications[app1Name].Type())
-	assert.Equal(t, expectedResult.AppNames, result.AppNames)
+	assert.Equal(t, expectedResult.LaunchedAppNames, result.LaunchedAppNames)
 }
 
 func TestParserCMDS(t *testing.T) {

--- a/cmd/sealer/cmd/image/build.go
+++ b/cmd/sealer/cmd/image/build.go
@@ -432,8 +432,12 @@ func buildImageExtensionOnResult(result *parser.KubefileResult, imageType string
 		extension.Applications = append(extension.Applications, app)
 	}
 	extension.Launch.Cmds = result.RawCmds
-	extension.Launch.AppNames = result.AppNames
-	extension.Launch.AppConfigs = result.ApplicationConfigs
+	extension.Launch.AppNames = result.LaunchedAppNames
+
+	for _, appConfig := range result.ApplicationConfigs {
+		extension.Launch.AppConfigs = append(extension.Launch.AppConfigs, appConfig)
+	}
+
 	return extension
 }
 

--- a/pkg/define/application/types.go
+++ b/pkg/define/application/types.go
@@ -15,7 +15,8 @@
 package application
 
 const (
-	KubeApp  string = "kube"
-	HelmApp  string = "helm"
-	ShellApp string = "shell"
+	KubeApp    string = "kube"
+	HelmApp    string = "helm"
+	ShellApp   string = "shell"
+	UnknownApp string = "unknown"
 )

--- a/test/sealer_build_test.go
+++ b/test/sealer_build_test.go
@@ -29,7 +29,7 @@ var _ = Describe("sealer build", func() {
 
 	Context("testing build with cmds", func() {
 		BeforeEach(func() {
-			buildPath := filepath.Join(build.AppCmdsBuildDir())
+			buildPath := filepath.Join(build.WithCmdsBuildDir())
 			err := os.Chdir(buildPath)
 			testhelper.CheckErr(err)
 		})
@@ -66,7 +66,7 @@ var _ = Describe("sealer build", func() {
 
 	Context("testing build with launch", func() {
 		BeforeEach(func() {
-			buildPath := filepath.Join(build.AppLaunchBuildDir())
+			buildPath := filepath.Join(build.WithLaunchBuildDir())
 			err := os.Chdir(buildPath)
 			testhelper.CheckErr(err)
 		})
@@ -101,9 +101,44 @@ var _ = Describe("sealer build", func() {
 
 	})
 
+	Context("testing build with app cmds", func() {
+		BeforeEach(func() {
+			buildPath := filepath.Join(build.WithAPPCmdsBuildDir())
+			err := os.Chdir(buildPath)
+			testhelper.CheckErr(err)
+		})
+		AfterEach(func() {
+			err := os.Chdir(settings.DefaultTestEnvDir)
+			testhelper.CheckErr(err)
+		})
+
+		It("start to build with app cmds", func() {
+			imageName := build.GetBuildImageName()
+			cmd := build.NewArgsOfBuild().
+				SetKubeFile("Kubefile").
+				SetImageName(imageName).
+				SetContext(".").
+				String()
+			sess, err := testhelper.Start(cmd)
+			testhelper.CheckErr(err)
+			testhelper.CheckExit0(sess, settings.MaxWaiteTime)
+
+			// check: sealer images whether image exist
+			testhelper.CheckBeTrue(build.CheckIsImageExist(imageName))
+
+			//TODO check image spec content
+			// 1. launch app names
+			// 2. launch app cmds:
+
+			// clean: build image
+			testhelper.CheckErr(build.DeleteBuildImage(imageName))
+		})
+
+	})
+
 	Context("testing build with --image-list flag", func() {
 		BeforeEach(func() {
-			buildPath := filepath.Join(build.AppWithImageListFlagBuildDir())
+			buildPath := filepath.Join(build.WithImageListFlagBuildDir())
 			err := os.Chdir(buildPath)
 			testhelper.CheckErr(err)
 		})
@@ -142,7 +177,7 @@ var _ = Describe("sealer build", func() {
 
 		BeforeEach(func() {
 			registry.Login()
-			buildPath := filepath.Join(build.MultiArchBuildDir())
+			buildPath := filepath.Join(build.WithMultiArchBuildDir())
 			err := os.Chdir(buildPath)
 			testhelper.CheckErr(err)
 

--- a/test/suites/build/build.go
+++ b/test/suites/build/build.go
@@ -28,22 +28,27 @@ func GetBuildImageName() string {
 	return "docker.io/sealerio/build-test:v1"
 }
 
-func AppCmdsBuildDir() string {
+func WithCmdsBuildDir() string {
 	return filepath.Join(settings.DefaultTestEnvDir, "suites", "build", "fixtures",
 		"build_with_cmds")
 }
 
-func AppWithImageListFlagBuildDir() string {
+func WithImageListFlagBuildDir() string {
 	return filepath.Join(settings.DefaultTestEnvDir, "suites", "build", "fixtures",
 		"build_with_imagelist_flag")
 }
 
-func AppLaunchBuildDir() string {
+func WithLaunchBuildDir() string {
 	return filepath.Join(settings.DefaultTestEnvDir, "suites", "build", "fixtures",
 		"build_with_launch")
 }
 
-func MultiArchBuildDir() string {
+func WithAPPCmdsBuildDir() string {
+	return filepath.Join(settings.DefaultTestEnvDir, "suites", "build", "fixtures",
+		"build_with_appcmds")
+}
+
+func WithMultiArchBuildDir() string {
 	return filepath.Join(settings.DefaultTestEnvDir, "suites", "build", "fixtures",
 		"build_with_multi_arch")
 }

--- a/test/suites/build/fixtures/build_with_appcmds/Kubefile
+++ b/test/suites/build/fixtures/build_with_appcmds/Kubefile
@@ -1,0 +1,6 @@
+FROM scratch
+APP yamlapp local://yamlcontext
+APP shellapp local://shellcontext
+APP mixedapp local://install.sh local://mixedcontext
+APPCMDS mixedapp ["kubectl apply -f app.yaml"]
+LAUNCH ["mixedapp","shellapp"]

--- a/test/suites/build/fixtures/build_with_appcmds/install.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/install.sh
@@ -1,3 +1,17 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kubectl get ns
 kubectl get nodes
 kubectl get ns

--- a/test/suites/build/fixtures/build_with_appcmds/install.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/install.sh
@@ -1,0 +1,4 @@
+kubectl get ns
+kubectl get nodes
+kubectl get ns
+kubectl get nodes

--- a/test/suites/build/fixtures/build_with_appcmds/mixedcontext/app.yaml
+++ b/test/suites/build/fixtures/build_with_appcmds/mixedcontext/app.yaml
@@ -1,0 +1,34 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: ns-test
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:alpine
+          ports:
+            - containerPort: 80

--- a/test/suites/build/fixtures/build_with_appcmds/mixedcontext/install.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/mixedcontext/install.sh
@@ -1,3 +1,17 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kubectl get ns
 kubectl get nodes
 kubectl get ns

--- a/test/suites/build/fixtures/build_with_appcmds/mixedcontext/install.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/mixedcontext/install.sh
@@ -1,0 +1,4 @@
+kubectl get ns
+kubectl get nodes
+kubectl get ns
+kubectl get nodes

--- a/test/suites/build/fixtures/build_with_appcmds/shellcontext/a.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/shellcontext/a.sh
@@ -1,0 +1,14 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kubectl get nodes

--- a/test/suites/build/fixtures/build_with_appcmds/shellcontext/b.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/shellcontext/b.sh
@@ -1,0 +1,14 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kubectl get pods

--- a/test/suites/build/fixtures/build_with_appcmds/shellcontext/c.sh
+++ b/test/suites/build/fixtures/build_with_appcmds/shellcontext/c.sh
@@ -1,0 +1,14 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kubectl get ns

--- a/test/suites/build/fixtures/build_with_appcmds/yamlcontext/a.yaml
+++ b/test/suites/build/fixtures/build_with_appcmds/yamlcontext/a.yaml
@@ -1,0 +1,17 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-test-a

--- a/test/suites/build/fixtures/build_with_appcmds/yamlcontext/b.yaml
+++ b/test/suites/build/fixtures/build_with_appcmds/yamlcontext/b.yaml
@@ -1,0 +1,17 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-test-b

--- a/test/suites/build/fixtures/build_with_appcmds/yamlcontext/c.yaml
+++ b/test/suites/build/fixtures/build_with_appcmds/yamlcontext/c.yaml
@@ -1,0 +1,17 @@
+# Copyright © 2023 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-test-c


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

kubefile:

```shell
FROM scratch
APP yamlapp local://yamlcontext
APP shellapp local://shellcontext
APP mixedapp local://install.sh local://mixedcontext
APPCMDS mixedapp ["kubectl apply -f app.yaml"]
LAUNCH ["mixedapp","shellapp"]
```

```
├── context
│   ├── app.yaml
│   └── install.sh
├── install.sh
├── Kubefile
├── shellcontext
│   ├── a.sh
│   ├── b.sh
│   └── c.sh
└── yamlcontext
    ├── a.yaml
    ├── b.yaml
    └── c.yaml
```

if app build context is mixed, need to specify `APPCMDS` if no app type is detected. 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
