### PR TITLE
chore: update some deprecated tools in github action

### DIFF
--- a/.github/workflows/e2e-test-apply.yml
+++ b/.github/workflows/e2e-test-apply.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Github API Request
         id: request
-        uses: octokit/request-action@v2.0.2
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -41,9 +41,9 @@ jobs:
       - name: Get PR informations
         id: pr_data
         run: |
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+          echo "repo_name=${{ fromJson(steps.request.outputs.data).head.repo.full_name }}" >> $GITHUB_STATE
+          echo "repo_clone_url=${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}" >> $GITHUB_STATE
+          echo "repo_ssh_url=${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}" >> $GITHUB_STATE
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test-build.yml
+++ b/.github/workflows/e2e-test-build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Github API Request
         id: request
-        uses: octokit/request-action@v2.0.2
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -41,9 +41,9 @@ jobs:
       - name: Get PR informations
         id: pr_data
         run: |
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+          echo "repo_name=${{ fromJson(steps.request.outputs.data).head.repo.full_name }}" >> $GITHUB_STATE
+          echo "repo_clone_url=${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}" >> $GITHUB_STATE
+          echo "repo_ssh_url=${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}" >> $GITHUB_STATE
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test-image.yml
+++ b/.github/workflows/e2e-test-image.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Github API Request
         id: request
-        uses: octokit/request-action@v2.0.2
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -41,9 +41,9 @@ jobs:
       - name: Get PR informations
         id: pr_data
         run: |
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+          echo "repo_name=${{ fromJson(steps.request.outputs.data).head.repo.full_name }}" >> $GITHUB_STATE
+          echo "repo_clone_url=${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}" >> $GITHUB_STATE
+          echo "repo_ssh_url=${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}" >> $GITHUB_STATE
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test-run.yml
+++ b/.github/workflows/e2e-test-run.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Github API Request
         id: request
-        uses: octokit/request-action@v2.0.2
+        uses: octokit/request-action@v2.1.7
         with:
           route: ${{ github.event.issue.pull_request.url }}
         env:
@@ -41,9 +41,9 @@ jobs:
       - name: Get PR informations
         id: pr_data
         run: |
-          echo "::set-output name=repo_name::${{ fromJson(steps.request.outputs.data).head.repo.full_name }}"
-          echo "::set-output name=repo_clone_url::${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}"
-          echo "::set-output name=repo_ssh_url::${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}"
+          echo "repo_name=${{ fromJson(steps.request.outputs.data).head.repo.full_name }}" >> $GITHUB_STATE
+          echo "repo_clone_url=${{ fromJson(steps.request.outputs.data).head.repo.clone_url }}" >> $GITHUB_STATE
+          echo "repo_ssh_url=${{ fromJson(steps.request.outputs.data).head.repo.ssh_url }}" >> $GITHUB_STATE
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: src/github.com/sealerio/sealer
 
       - name: Save build binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sealer-binaries
           path: src/github.com/sealerio/sealer/_output/assets/*.tar.gz*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: contentrel
         run: |
           RELEASEVER=${{ github.ref }}
-          echo "::set-output name=stringver::${RELEASEVER#refs/tags/v}"
+          echo "stringver=${RELEASEVER#refs/tags/v}" >> $GITHUB_STATE
         working-directory: src/github.com/sealerio/sealer
 
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run go test and generate coverage
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic `go list ./... | grep -v /test`
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
chore: update some deprecated tools in github action
we can find some warning in workflow annotations like:
```bash
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
