### PR TITLE
use new k8s registry

### DIFF
--- a/build/layerutils/manifests/manifests_test.go
+++ b/build/layerutils/manifests/manifests_test.go
@@ -27,7 +27,7 @@ package manifest
 		{
 			"test list manifests images",
 			args{"my_cluster"},
-			[]string{"k8s.gcr.io/etcd:3.4.13-0", "k8s.gcr.io/kube-apiserver:v1.19.7", "k8s.gcr.io/kube-controller-manager:v1.19.7", "k8s.gcr.io/kube-scheduler:v1.19.7"},
+			[]string{"registry.k8s.io/etcd:3.4.13-0", "registry.k8s.io/kube-apiserver:v1.19.7", "registry.k8s.io/kube-controller-manager:v1.19.7", "registry.k8s.io/kube-scheduler:v1.19.7"},
 			false,
 		},
 	}

--- a/docs/api/cloudrootfs.md
+++ b/docs/api/cloudrootfs.md
@@ -95,8 +95,8 @@ Write the image list which your want involved in ClusterImage into imageList, fo
 
 ```
 docker.io/alpine:3.17.1
-k8s.gcr.io/pause:3.5
-k8s.gcr.io/kube-apiserver:v1.22.17
+registry.k8s.io/pause:3.5
+registry.k8s.io/kube-apiserver:v1.22.17
 ```
 
 ## scripts

--- a/pkg/image/save/save_test.go
+++ b/pkg/image/save/save_test.go
@@ -49,8 +49,8 @@ func Test_splitDockerDomain(t *testing.T) {
 		},
 		{
 			name:       "test3",
-			imageName:  "k8s.gcr.io/kube-apiserver",
-			wantDomain: "k8s.gcr.io",
+			imageName:  "registry.k8s.io/kube-apiserver",
+			wantDomain: "registry.k8s.io",
 			wantRemain: "kube-apiserver",
 		},
 	}
@@ -87,8 +87,8 @@ func Test_parseNormalizedNamed(t *testing.T) {
 		},
 		{
 			name:       "test3",
-			imageName:  "k8s.gcr.io/kube-apiserver",
-			wantDomain: "k8s.gcr.io",
+			imageName:  "registry.k8s.io/kube-apiserver",
+			wantDomain: "registry.k8s.io",
 			wantRepo:   "kube-apiserver",
 			wantTag:    defaultTag,
 		},

--- a/vendor/k8s.io/api/core/v1/generated.proto
+++ b/vendor/k8s.io/api/core/v1/generated.proto
@@ -785,7 +785,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   // +optional
   repeated string names = 1;
 

--- a/vendor/k8s.io/api/core/v1/types.go
+++ b/vendor/k8s.io/api/core/v1/types.go
@@ -3607,7 +3607,8 @@ type PodDNSConfigOption struct {
 
 // IP address information for entries in the (plural) PodIPs field.
 // Each entry includes:
-//    IP: An IP address allocated to the pod. Routable at least within the cluster.
+//
+//	IP: An IP address allocated to the pod. Routable at least within the cluster.
 type PodIP struct {
 	// ip is an IP address (IPv4 or IPv6) assigned to the pod
 	IP string `json:"ip,omitempty" protobuf:"bytes,1,opt,name=ip"`
@@ -4669,17 +4670,18 @@ type ServiceAccountList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Endpoints is a collection of endpoints that implement the actual service. Example:
-//   Name: "mysvc",
-//   Subsets: [
-//     {
-//       Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
-//       Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
-//     },
-//     {
-//       Addresses: [{"ip": "10.10.3.3"}],
-//       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
-//     },
-//  ]
+//
+//	 Name: "mysvc",
+//	 Subsets: [
+//	   {
+//	     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//	     Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//	   },
+//	   {
+//	     Addresses: [{"ip": "10.10.3.3"}],
+//	     Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
+//	   },
+//	]
 type Endpoints struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -4701,13 +4703,16 @@ type Endpoints struct {
 // EndpointSubset is a group of addresses with a common set of ports. The
 // expanded set of endpoints is the Cartesian product of Addresses x Ports.
 // For example, given:
-//   {
-//     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
-//     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
-//   }
+//
+//	{
+//	  Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+//	  Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+//	}
+//
 // The resulting set of endpoints can be viewed as:
-//     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
-//     b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+//
+//	a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+//	b: [ 10.10.1.1:309, 10.10.2.2:309 ]
 type EndpointSubset struct {
 	// IP addresses which offer the related ports that are marked as ready. These endpoints
 	// should be considered safe for load balancers and clients to utilize.
@@ -5058,7 +5063,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	// +optional
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
@@ -5580,6 +5585,7 @@ type ServiceProxyOptions struct {
 //     and the version of the actual struct is irrelevant.
 //  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
 //     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+//
 // Instead of using this type, create a locally provided and used type that is well-focused on your reference.
 // For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -356,7 +356,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"registry.k8s.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -106,8 +106,8 @@ type ClusterConfiguration struct {
 	CertificatesDir string
 
 	// ImageRepository sets the container registry to pull images from.
-	// If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
-	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+	// If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
 	// will be used for all the other images.
 	ImageRepository string
 

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/defaults.go
@@ -39,7 +39,7 @@ const (
 	// DefaultCertificatesDir defines default certificate directory
 	DefaultCertificatesDir = "/etc/kubernetes/pki"
 	// DefaultImageRepository defines default image registry
-	DefaultImageRepository = "k8s.gcr.io"
+	DefaultImageRepository = "registry.k8s.io"
 	// DefaultManifestsDir defines default manifests directory
 	DefaultManifestsDir = "/etc/kubernetes/manifests"
 	// DefaultClusterName defines the default cluster name

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/doc.go
@@ -23,22 +23,23 @@ limitations under the License.
 // This version improves on the v1beta1 format by fixing some minor issues and adding a few new fields.
 //
 // A list of changes since v1beta1:
-//	- "certificateKey" field is added to InitConfiguration and JoinConfiguration.
-//	- "ignorePreflightErrors" field is added to the NodeRegistrationOptions.
-//	- The JSON "omitempty" tag is used in a more places where appropriate.
-//	- The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed.
-//	See the Kubernetes 1.15 changelog for further details.
+//   - "certificateKey" field is added to InitConfiguration and JoinConfiguration.
+//   - "ignorePreflightErrors" field is added to the NodeRegistrationOptions.
+//   - The JSON "omitempty" tag is used in a more places where appropriate.
+//   - The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed.
+//     See the Kubernetes 1.15 changelog for further details.
 //
-// Migration from old kubeadm config versions
+// # Migration from old kubeadm config versions
 //
 // Please convert your v1beta1 configuration files to v1beta2 using the "kubeadm config migrate" command of kubeadm v1.15.x
 // (conversion from older releases of kubeadm config files requires older release of kubeadm as well e.g.
+//
 //	kubeadm v1.11 should be used to migrate v1alpha1 to v1alpha2; kubeadm v1.12 should be used to translate v1alpha2 to v1alpha3;
 //	kubeadm v1.13 or v1.14 should be used to translate v1alpha3 to v1beta1)
 //
 // Nevertheless, kubeadm v1.15.x will support reading from v1beta1 version of the kubeadm config file format.
 //
-// Basics
+// # Basics
 //
 // The preferred way to configure kubeadm is to pass an YAML configuration file with the --config option. Some of the
 // configuration options defined in the kubeadm config file are also available as command line flags, but only
@@ -48,24 +49,25 @@ limitations under the License.
 //
 // kubeadm supports the following configuration types:
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: InitConfiguration
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: InitConfiguration
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: ClusterConfiguration
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: ClusterConfiguration
 //
-//     apiVersion: kubelet.config.k8s.io/v1beta1
-//     kind: KubeletConfiguration
+//	apiVersion: kubelet.config.k8s.io/v1beta1
+//	kind: KubeletConfiguration
 //
-//     apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//     kind: KubeProxyConfiguration
+//	apiVersion: kubeproxy.config.k8s.io/v1alpha1
+//	kind: KubeProxyConfiguration
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: JoinConfiguration
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: JoinConfiguration
 //
 // To print the defaults for "init" and "join" actions use the following commands:
-//  kubeadm config print init-defaults
-//  kubeadm config print join-defaults
+//
+//	kubeadm config print init-defaults
+//	kubeadm config print join-defaults
 //
 // The list of configuration types that must be included in a configuration file depends by the action you are
 // performing (init or join) and by the configuration options you are going to use (defaults or advanced customization).
@@ -80,18 +82,18 @@ limitations under the License.
 // If the user provides a configuration types that is not expected for the action you are performing, kubeadm will
 // ignore those types and print a warning.
 //
-// Kubeadm init configuration types
+// # Kubeadm init configuration types
 //
 // When executing kubeadm init with the --config option, the following configuration types could be used:
 // InitConfiguration, ClusterConfiguration, KubeProxyConfiguration, KubeletConfiguration, but only one
 // between InitConfiguration and ClusterConfiguration is mandatory.
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: InitConfiguration
-//     bootstrapTokens:
-//         ...
-//     nodeRegistration:
-//         ...
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: InitConfiguration
+//	bootstrapTokens:
+//	    ...
+//	nodeRegistration:
+//	    ...
 //
 // The InitConfiguration type should be used to configure runtime settings, that in case of kubeadm init
 // are the configuration of the bootstrap token and all the setting which are specific to the node where kubeadm
@@ -104,18 +106,18 @@ limitations under the License.
 // - LocalAPIEndpoint, that represents the endpoint of the instance of the API server to be deployed on this node;
 // use it e.g. to customize the API server advertise address.
 //
-//     apiVersion: kubeadm.k8s.io/v1beta2
-//     kind: ClusterConfiguration
-//     networking:
-//         ...
-//     etcd:
-//         ...
-//     apiServer:
-//       extraArgs:
-//         ...
-//       extraVolumes:
-//         ...
-//     ...
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: ClusterConfiguration
+//	networking:
+//	    ...
+//	etcd:
+//	    ...
+//	apiServer:
+//	  extraArgs:
+//	    ...
+//	  extraVolumes:
+//	    ...
+//	...
 //
 // The ClusterConfiguration type should be used to configure cluster-wide settings,
 // including settings for:
@@ -129,9 +131,9 @@ limitations under the License.
 // - kube-apiserver, kube-scheduler, kube-controller-manager configurations; use it to customize control-plane
 // components by adding customized setting or overriding kubeadm default settings.
 //
-//    apiVersion: kubeproxy.config.k8s.io/v1alpha1
-//    kind: KubeProxyConfiguration
-//       ...
+//	apiVersion: kubeproxy.config.k8s.io/v1alpha1
+//	kind: KubeProxyConfiguration
+//	   ...
 //
 // The KubeProxyConfiguration type should be used to change the configuration passed to kube-proxy instances deployed
 // in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
@@ -139,9 +141,9 @@ limitations under the License.
 // See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ or https://godoc.org/k8s.io/kube-proxy/config/v1alpha1#KubeProxyConfiguration
 // for kube proxy official documentation.
 //
-//    apiVersion: kubelet.config.k8s.io/v1beta1
-//    kind: KubeletConfiguration
-//       ...
+//	apiVersion: kubelet.config.k8s.io/v1beta1
+//	kind: KubeletConfiguration
+//	   ...
 //
 // The KubeletConfiguration type should be used to change the configurations that will be passed to all kubelet instances
 // deployed in the cluster. If this object is not provided or provided only partially, kubeadm applies defaults.
@@ -152,113 +154,113 @@ limitations under the License.
 // Here is a fully populated example of a single YAML file containing multiple
 // configuration types to be used during a `kubeadm init` run.
 //
-// 	apiVersion: kubeadm.k8s.io/v1beta2
-// 	kind: InitConfiguration
-// 	bootstrapTokens:
-// 	- token: "9a08jv.c0izixklcxtmnze7"
-// 	  description: "kubeadm bootstrap token"
-// 	  ttl: "24h"
-// 	- token: "783bde.3f89s0fje9f38fhf"
-// 	  description: "another bootstrap token"
-// 	  usages:
-// 	  - authentication
-// 	  - signing
-// 	  groups:
-// 	  - system:bootstrappers:kubeadm:default-node-token
-// 	nodeRegistration:
-// 	  name: "ec2-10-100-0-1"
-// 	  criSocket: "/var/run/dockershim.sock"
-// 	  taints:
-// 	  - key: "kubeadmNode"
-// 	    value: "master"
-// 	    effect: "NoSchedule"
-// 	  kubeletExtraArgs:
-// 	    cgroup-driver: "cgroupfs"
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: InitConfiguration
+//	bootstrapTokens:
+//	- token: "9a08jv.c0izixklcxtmnze7"
+//	  description: "kubeadm bootstrap token"
+//	  ttl: "24h"
+//	- token: "783bde.3f89s0fje9f38fhf"
+//	  description: "another bootstrap token"
+//	  usages:
+//	  - authentication
+//	  - signing
+//	  groups:
+//	  - system:bootstrappers:kubeadm:default-node-token
+//	nodeRegistration:
+//	  name: "ec2-10-100-0-1"
+//	  criSocket: "/var/run/dockershim.sock"
+//	  taints:
+//	  - key: "kubeadmNode"
+//	    value: "master"
+//	    effect: "NoSchedule"
+//	  kubeletExtraArgs:
+//	    cgroup-driver: "cgroupfs"
 //	  ignorePreflightErrors:
 //	  - IsPrivilegedUser
-// 	localAPIEndpoint:
-// 	  advertiseAddress: "10.100.0.1"
-// 	  bindPort: 6443
+//	localAPIEndpoint:
+//	  advertiseAddress: "10.100.0.1"
+//	  bindPort: 6443
 //	certificateKey: "e6a2eb8581237ab72a4f494f30285ec12a9694d750b9785706a83bfcbbbd2204"
-// 	---
-// 	apiVersion: kubeadm.k8s.io/v1beta2
-// 	kind: ClusterConfiguration
-// 	etcd:
-// 	  # one of local or external
-// 	  local:
-// 	    imageRepository: "k8s.gcr.io"
-// 	    imageTag: "3.2.24"
-// 	    dataDir: "/var/lib/etcd"
-// 	    extraArgs:
-// 	      listen-client-urls: "http://10.100.0.1:2379"
-// 	    serverCertSANs:
-// 	    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	    peerCertSANs:
-// 	    - "10.100.0.1"
-// 	  # external:
-// 	    # endpoints:
-// 	    # - "10.100.0.1:2379"
-// 	    # - "10.100.0.2:2379"
-// 	    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
-// 	    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
-// 	    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
-// 	networking:
-// 	  serviceSubnet: "10.96.0.0/12"
-// 	  podSubnet: "10.100.0.1/24"
-// 	  dnsDomain: "cluster.local"
-// 	kubernetesVersion: "v1.12.0"
-// 	controlPlaneEndpoint: "10.100.0.1:6443"
-// 	apiServer:
-// 	  extraArgs:
-// 	    authorization-mode: "Node,RBAC"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	  certSANs:
-// 	  - "10.100.1.1"
-// 	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
-// 	  timeoutForControlPlane: 4m0s
-// 	controllerManager:
-// 	  extraArgs:
-// 	    "node-cidr-mask-size": "20"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	scheduler:
-// 	  extraArgs:
-// 	    address: "10.100.0.1"
-// 	  extraVolumes:
-// 	  - name: "some-volume"
-// 	    hostPath: "/etc/some-path"
-// 	    mountPath: "/etc/some-pod-path"
-// 	    readOnly: false
-// 	    pathType: File
-// 	certificatesDir: "/etc/kubernetes/pki"
-// 	imageRepository: "k8s.gcr.io"
-// 	useHyperKubeImage: false
-// 	clusterName: "example-cluster"
-// 	---
-// 	apiVersion: kubelet.config.k8s.io/v1beta1
-// 	kind: KubeletConfiguration
-// 	# kubelet specific options here
-// 	---
-// 	apiVersion: kubeproxy.config.k8s.io/v1alpha1
-// 	kind: KubeProxyConfiguration
-// 	# kube-proxy specific options here
+//	---
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: ClusterConfiguration
+//	etcd:
+//	  # one of local or external
+//	  local:
+//	    imageRepository: "registry.k8s.io"
+//	    imageTag: "3.2.24"
+//	    dataDir: "/var/lib/etcd"
+//	    extraArgs:
+//	      listen-client-urls: "http://10.100.0.1:2379"
+//	    serverCertSANs:
+//	    -  "ec2-10-100-0-1.compute-1.amazonaws.com"
+//	    peerCertSANs:
+//	    - "10.100.0.1"
+//	  # external:
+//	    # endpoints:
+//	    # - "10.100.0.1:2379"
+//	    # - "10.100.0.2:2379"
+//	    # caFile: "/etcd/kubernetes/pki/etcd/etcd-ca.crt"
+//	    # certFile: "/etcd/kubernetes/pki/etcd/etcd.crt"
+//	    # keyFile: "/etcd/kubernetes/pki/etcd/etcd.key"
+//	networking:
+//	  serviceSubnet: "10.96.0.0/12"
+//	  podSubnet: "10.100.0.1/24"
+//	  dnsDomain: "cluster.local"
+//	kubernetesVersion: "v1.12.0"
+//	controlPlaneEndpoint: "10.100.0.1:6443"
+//	apiServer:
+//	  extraArgs:
+//	    authorization-mode: "Node,RBAC"
+//	  extraVolumes:
+//	  - name: "some-volume"
+//	    hostPath: "/etc/some-path"
+//	    mountPath: "/etc/some-pod-path"
+//	    readOnly: false
+//	    pathType: File
+//	  certSANs:
+//	  - "10.100.1.1"
+//	  - "ec2-10-100-0-1.compute-1.amazonaws.com"
+//	  timeoutForControlPlane: 4m0s
+//	controllerManager:
+//	  extraArgs:
+//	    "node-cidr-mask-size": "20"
+//	  extraVolumes:
+//	  - name: "some-volume"
+//	    hostPath: "/etc/some-path"
+//	    mountPath: "/etc/some-pod-path"
+//	    readOnly: false
+//	    pathType: File
+//	scheduler:
+//	  extraArgs:
+//	    address: "10.100.0.1"
+//	  extraVolumes:
+//	  - name: "some-volume"
+//	    hostPath: "/etc/some-path"
+//	    mountPath: "/etc/some-pod-path"
+//	    readOnly: false
+//	    pathType: File
+//	certificatesDir: "/etc/kubernetes/pki"
+//	imageRepository: "registry.k8s.io"
+//	useHyperKubeImage: false
+//	clusterName: "example-cluster"
+//	---
+//	apiVersion: kubelet.config.k8s.io/v1beta1
+//	kind: KubeletConfiguration
+//	# kubelet specific options here
+//	---
+//	apiVersion: kubeproxy.config.k8s.io/v1alpha1
+//	kind: KubeProxyConfiguration
+//	# kube-proxy specific options here
 //
-// Kubeadm join configuration types
+// # Kubeadm join configuration types
 //
 // When executing kubeadm join with the --config option, the JoinConfiguration type should be provided.
 //
-//    apiVersion: kubeadm.k8s.io/v1beta2
-//    kind: JoinConfiguration
-//       ...
+//	apiVersion: kubeadm.k8s.io/v1beta2
+//	kind: JoinConfiguration
+//	   ...
 //
 // The JoinConfiguration type should be used to configure runtime settings, that in case of kubeadm join
 // are the discovery method used for accessing the cluster info and all the setting which are specific
@@ -269,7 +271,6 @@ limitations under the License.
 // node only (e.g. the node ip).
 //
 // - APIEndpoint, that represents the endpoint of the instance of the API server to be eventually deployed on this node.
-//
 package v1beta2 // import "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 
 //TODO: The BootstrapTokenString object should move out to either k8s.io/client-go or k8s.io/api in the future

--- a/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
+++ b/vendor/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2/types.go
@@ -96,8 +96,8 @@ type ClusterConfiguration struct {
 	CertificatesDir string `json:"certificatesDir,omitempty"`
 
 	// ImageRepository sets the container registry to pull images from.
-	// If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
-	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io`
+	// If empty, `registry.k8s.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+	// `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `registry.k8s.io`
 	// will be used for all the other images.
 	ImageRepository string `json:"imageRepository,omitempty"`
 


### PR DESCRIPTION
Fixes - #2073 

Problem: Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp. Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution: As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This commit migrates remaining references for kubevirt/hostpath-provisioner to registry.k8s.io.

Which issue(s) this PR fixes
Relates to umbrella issue https://github.com/kubernetes/k8s.io/issues/4780
