### PR TITLE
feature: dump localRegistry to cluster

### DIFF
--- a/cmd/sealer/cmd/cluster/upgrade.go
+++ b/cmd/sealer/cmd/cluster/upgrade.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sealerio/sealer/pkg/imagedistributor"
 	"github.com/sealerio/sealer/pkg/imageengine"
 	"github.com/sealerio/sealer/pkg/infradriver"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"

--- a/pkg/registry/configurator.go
+++ b/pkg/registry/configurator.go
@@ -18,13 +18,22 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/sealerio/sealer/pkg/imagedistributor"
-
-	v2 "github.com/sealerio/sealer/types/api/v2"
-
 	containerruntime "github.com/sealerio/sealer/pkg/container-runtime"
+	"github.com/sealerio/sealer/pkg/imagedistributor"
 	"github.com/sealerio/sealer/pkg/infradriver"
+	v2 "github.com/sealerio/sealer/types/api/v2"
 )
+
+type LocalRegistryInfo struct {
+	*v2.LocalRegistry
+	DeployHosts []net.IP `json:"deployHosts,omitempty"`
+	Vip         string   `json:"vip,omitempty"`
+}
+
+type RegistryInfo struct { // nolint
+	External *v2.ExternalRegistry `json:"external,omitempty"`
+	Local    LocalRegistryInfo    `json:"local,omitempty"`
+}
 
 // Configurator provide registry configuration management
 type Configurator interface {
@@ -35,6 +44,8 @@ type Configurator interface {
 	UninstallFrom(masters, nodes []net.IP) error
 
 	GetDriver() (Driver, error)
+
+	GetRegistryInfo() RegistryInfo
 }
 
 func NewConfigurator(deployHosts []net.IP,

--- a/pkg/registry/external.go
+++ b/pkg/registry/external.go
@@ -38,6 +38,13 @@ type externalConfigurator struct {
 	password             string
 }
 
+func (e *externalConfigurator) GetRegistryInfo() RegistryInfo {
+	clusterRegistry := e.infraDriver.GetClusterRegistry()
+	return RegistryInfo{
+		External: clusterRegistry.ExternalRegistry,
+	}
+}
+
 func (e *externalConfigurator) InstallOn(masters, nodes []net.IP) error {
 	hosts := append(masters, nodes...)
 	var (


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
#2056 
dump localRegistry to configMap

ha == true:
```shell
apiVersion: v1
data:
  registry: |
    external: null
    local:
      localregistry:
        registryconfig:
          domain: sea.hub
          port: 5000
          username: ""
          password: ""
        ha: true
        insecure: false
        cert:
          subjectaltname: null
      deployhosts:
      - 172.16.130.23
      - 172.16.130.24
      - 172.16.130.25
      vip: 10.103.97.2
kind: ConfigMap
metadata:
  creationTimestamp: "2023-04-10T02:43:55Z"
  name: sealer-registry
  namespace: kube-system
  resourceVersion: "758"
  uid: e7fc155e-cc73-4894-959b-a628e8c3f5e1
```


ha == false:
```shell
apiVersion: v1
data:
  registry: |
    external: null
    local:
      localregistry:
        registryconfig:
          domain: sea.hub
          port: 5000
          username: ""
          password: ""
        ha: false
        insecure: false
        cert:
          subjectaltname: null
      deployhosts:
      - 172.16.130.23
      vip: ""
kind: ConfigMap
metadata:
  creationTimestamp: "2023-04-10T01:52:24Z"
  name: sealer-registry
  namespace: kube-system
  resourceVersion: "734"
  uid: cb59317a-8f5e-4afc-9c84-863a981213d2
```


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
