### PR TITLE
support set tmp dir for load image

### DIFF
--- a/cmd/sealer/cmd/image/load.go
+++ b/cmd/sealer/cmd/image/load.go
@@ -58,6 +58,7 @@ func NewLoadCmd() *cobra.Command {
 	flags := loadCmd.Flags()
 	flags.StringVarP(&loadOpts.Input, "input", "i", "", "Load image from file")
 	flags.BoolVarP(&loadOpts.Quiet, "quiet", "q", false, "Suppress the output")
+	flags.StringVar(&loadOpts.TmpDir, "tmp-dir", "", "set temporary directory when load image. if not set, use system`s temporary directory")
 	if err := loadCmd.MarkFlagRequired("input"); err != nil {
 		logrus.Errorf("failed to init flag: %v", err)
 		os.Exit(1)

--- a/pkg/define/options/options.go
+++ b/pkg/define/options/options.go
@@ -131,8 +131,9 @@ type SaveOptions struct {
 }
 
 type LoadOptions struct {
-	Input string
-	Quiet bool
+	Input  string
+	TmpDir string
+	Quiet  bool
 }
 
 type InspectOptions struct {

--- a/pkg/imageengine/buildah/load.go
+++ b/pkg/imageengine/buildah/load.go
@@ -56,7 +56,7 @@ func (engine *Engine) Load(opts *options.LoadOptions) error {
 		}
 	}()
 
-	tempDir, err := os.MkdirTemp("", "sealer-load-tmp")
+	tempDir, err := os.MkdirTemp(opts.TmpDir, "sealer-load-tmp")
 	if err != nil {
 		return fmt.Errorf("failed to create %s, err: %v", tempDir, err)
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

we could support set tmp dir for load image. In this way, it is possible to separate the temporary directory from the system disk

Example as below :

`sealer load -i myimage.tar --tmp-dir /my/tmp/disk`


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
