### PR TITLE
feat: support env rendering for files in application/apps 

### DIFF
--- a/pkg/application/files.go
+++ b/pkg/application/files.go
@@ -1,0 +1,119 @@
+// Copyright © 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package application
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/imdario/mergo"
+	"github.com/sealerio/sealer/pkg/env"
+	v2 "github.com/sealerio/sealer/types/api/v2"
+	osUtils "github.com/sealerio/sealer/utils/os"
+	"gopkg.in/yaml.v3"
+)
+
+func newFileProcessor(appFile v2.AppFile) (FileProcessor, error) {
+	switch appFile.Strategy {
+	case v2.OverWriteStrategy:
+		return overWriteProcessor{appFile}, nil
+	case v2.MergeStrategy:
+		return mergeProcessor{appFile}, nil
+	}
+
+	return nil, fmt.Errorf("failed to init fileProcessor,%s is not register", appFile.Strategy)
+}
+
+// overWriteProcessor :this will overwrite the FilePath with the Values.
+type overWriteProcessor struct {
+	v2.AppFile
+}
+
+func (r overWriteProcessor) Process(appRoot string) error {
+	target := filepath.Join(appRoot, r.Path)
+
+	err := osUtils.NewCommonWriter(target).WriteFile([]byte(r.Data))
+	if err != nil {
+		return fmt.Errorf("failed to write to file %s with raw mode: %v", target, err)
+	}
+	return nil
+}
+
+// mergeProcessor :this will merge the FilePath with the Values.
+//Only files in yaml format are supported.
+//if Strategy is "merge" will deeply merge each yaml file section.
+type mergeProcessor struct {
+	v2.AppFile
+}
+
+func (m mergeProcessor) Process(appRoot string) error {
+	var (
+		result     [][]byte
+		srcDataMap = make(map[string]interface{})
+	)
+
+	err := yaml.Unmarshal([]byte(m.Data), &srcDataMap)
+	if err != nil {
+		return fmt.Errorf("failed to load config data: %v", err)
+	}
+
+	target := filepath.Join(appRoot, m.Path)
+	contents, err := os.ReadFile(filepath.Clean(target))
+	if err != nil {
+		return err
+	}
+
+	for _, section := range bytes.Split(contents, []byte("---\n")) {
+		destDataMap := make(map[string]interface{})
+
+		err = yaml.Unmarshal(section, &destDataMap)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal config data: %v", err)
+		}
+
+		err = mergo.Merge(&destDataMap, &srcDataMap, mergo.WithOverride)
+		if err != nil {
+			return fmt.Errorf("failed to merge config: %v", err)
+		}
+
+		out, err := yaml.Marshal(destDataMap)
+		if err != nil {
+			return err
+		}
+
+		result = append(result, out)
+	}
+
+	err = osUtils.NewCommonWriter(target).WriteFile(bytes.Join(result, []byte("---\n")))
+	if err != nil {
+		return fmt.Errorf("failed to write to file %s with raw mode: %v", target, err)
+	}
+	return nil
+}
+
+//envRender :this will render the FilePath with the Values.
+type envRender struct {
+	envData map[string]string
+}
+
+func (e envRender) Process(appRoot string) error {
+	if len(e.envData) == 0 {
+		return nil
+	}
+
+	return env.RenderTemplate(appRoot, e.envData)
+}

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
+	mapUtils "github.com/sealerio/sealer/utils/maps"
 	"github.com/sealerio/sealer/utils/shellcommand"
 	"github.com/sealerio/sealer/utils/ssh"
 	strUtil "github.com/sealerio/sealer/utils/strings"
@@ -46,19 +47,6 @@ type SSHInfraDriver struct {
 	cluster      v2.Cluster
 }
 
-func mergeList(hostEnv, globalEnv map[string]string) map[string]string {
-	if len(hostEnv) == 0 {
-		return copyEnv(globalEnv)
-	}
-	for globalEnvKey, globalEnvValue := range globalEnv {
-		if _, ok := hostEnv[globalEnvKey]; ok {
-			continue
-		}
-		hostEnv[globalEnvKey] = globalEnvValue
-	}
-	return hostEnv
-}
-
 func convertTaints(taints []string) ([]k8sv1.Taint, error) {
 	var k8staints []k8sv1.Taint
 	for _, taint := range taints {
@@ -69,18 +57,6 @@ func convertTaints(taints []string) ([]k8sv1.Taint, error) {
 		k8staints = append(k8staints, data)
 	}
 	return k8staints, nil
-}
-
-func copyEnv(origin map[string]string) map[string]string {
-	if origin == nil {
-		return nil
-	}
-	ret := make(map[string]string, len(origin))
-	for k, v := range origin {
-		ret[k] = v
-	}
-
-	return ret
 }
 
 // NewInfraDriver will create a new Infra driver, and if extraEnv specified, it will set env not exist in Cluster
@@ -148,7 +124,7 @@ func NewInfraDriver(cluster *v2.Cluster) (InfraDriver, error) {
 	// merge the host ENV and global env, the host env will overwrite cluster.Spec.Env
 	for _, host := range cluster.Spec.Hosts {
 		for _, ip := range host.IPS {
-			ret.hostEnvMap[ip.String()] = mergeList(strUtil.ConvertStringSliceToMap(host.Env), ret.clusterEnv)
+			ret.hostEnvMap[ip.String()] = mapUtils.Merge(strUtil.ConvertStringSliceToMap(host.Env), ret.clusterEnv)
 			ret.hostLabels[ip.String()] = host.Labels
 			taints, err := convertTaints(host.Taints)
 			if err != nil {

--- a/types/api/v2/application_types.go
+++ b/types/api/v2/application_types.go
@@ -43,6 +43,13 @@ type ApplicationConfig struct {
 	// the AppName
 	Name string `json:"name,omitempty"`
 
+	// Env is a set of key value pair.
+	// it is app level, only this app will be aware of its existence,
+	// it is used to render app files, or as an environment variable for app startup and deletion commands
+	// it takes precedence over ApplicationSpec.Env.
+	Env []string `json:"env,omitempty"`
+
+	//Files indicates that how to modify the specific app files.
 	Files []AppFile `json:"files,omitempty"`
 
 	// app Launch customization
@@ -57,7 +64,6 @@ type Strategy string
 const (
 	OverWriteStrategy Strategy = "overwrite"
 	MergeStrategy     Strategy = "merge"
-	RenderStrategy    Strategy = "render"
 )
 
 type AppFile struct {
@@ -69,7 +75,6 @@ type AppFile struct {
 
 	// Enumeration value is "merge", "overwrite", "render". default value is "overwrite".
 	// OverWriteStrategy : this will overwrite the FilePath with the Data.
-	// RenderStrategy: this will render the FilePath with the Data.
 	// MergeStrategy: this will merge the FilePath with the Data, and only yaml files format are supported
 	Strategy Strategy `json:"strategy,omitempty"`
 

--- a/utils/maps/maps.go
+++ b/utils/maps/maps.go
@@ -14,17 +14,6 @@
 
 package maps
 
-// Merge :merge map type as overwrite model
-func Merge(ms ...map[string]string) map[string]string {
-	res := map[string]string{}
-	for _, m := range ms {
-		for k, v := range m {
-			res[k] = v
-		}
-	}
-	return res
-}
-
 // ConvertToSlice Use the equal sign to link key and value looks like key1=value1,key2=value2.
 func ConvertToSlice(m map[string]string) []string {
 	result := []string{}
@@ -32,4 +21,30 @@ func ConvertToSlice(m map[string]string) []string {
 		result = append(result, k+"="+v)
 	}
 	return result
+}
+
+// Merge :get all elements, only insert key which is not in dst form src.
+func Merge(dst, src map[string]string) map[string]string {
+	if len(dst) == 0 {
+		return Copy(src)
+	}
+	for srcEnvKey, srcEnvValue := range src {
+		if _, ok := dst[srcEnvKey]; ok {
+			continue
+		}
+		dst[srcEnvKey] = srcEnvValue
+	}
+	return dst
+}
+
+func Copy(origin map[string]string) map[string]string {
+	if origin == nil {
+		return nil
+	}
+	ret := make(map[string]string, len(origin))
+	for k, v := range origin {
+		ret[k] = v
+	}
+
+	return ret
 }

--- a/utils/maps/maps_test.go
+++ b/utils/maps/maps_test.go
@@ -1,0 +1,130 @@
+// Copyright © 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Merge(t *testing.T) {
+	src := map[string]string{
+		"key1":    "src1",
+		"key2":    "src2",
+		"key3":    "src3",
+		"src-key": "src-value",
+	}
+
+	dst := map[string]string{
+		"key1":    "v1",
+		"key2":    "v2",
+		"key3":    "v3",
+		"dst-key": "dst-value",
+	}
+
+	result := map[string]string{
+		"key1":    "v1",
+		"key2":    "v2",
+		"key3":    "v3",
+		"dst-key": "dst-value",
+		"src-key": "src-value",
+	}
+
+	nilDst := make(map[string]string)
+
+	type args struct {
+		src    map[string]string
+		dst    map[string]string
+		wanted map[string]string
+	}
+
+	var tests = []struct {
+		name string
+		args args
+	}{
+		{
+			name: "nil dst want get src as result",
+			args: args{
+				src:    src,
+				dst:    nilDst,
+				wanted: src,
+			},
+		},
+		{
+			name: "not nil dst want get overwriting dst with src as result",
+			args: args{
+				src:    src,
+				dst:    dst,
+				wanted: result,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.args.wanted, Merge(tt.args.dst, tt.args.src))
+		})
+	}
+}
+
+func Test_Copy(t *testing.T) {
+	src := map[string]string{
+		"key1":    "v1",
+		"key2":    "v2",
+		"key3":    "v3",
+		"dst-key": "dst-value",
+		"src-key": "src-value",
+	}
+
+	result := map[string]string{
+		"key1":    "v1",
+		"key2":    "v2",
+		"key3":    "v3",
+		"dst-key": "dst-value",
+		"src-key": "src-value",
+	}
+
+	type args struct {
+		src    map[string]string
+		wanted map[string]string
+	}
+
+	var tests = []struct {
+		name string
+		args args
+	}{
+		{
+			name: "nil src want get nil result",
+			args: args{
+				src:    nil,
+				wanted: nil,
+			},
+		},
+		{
+			name: "not nil src want same src as result",
+			args: args{
+				src:    src,
+				wanted: result,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.args.wanted, Copy(tt.args.src))
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. add  `ApplicationConfig.Env` for supporting app env render.
2. move out all app files modifying func to file.go

Clusterfile:

```yaml
apiVersion: sealer.io/v2
kind: Cluster
metadata:
  name: my-cluster
spec:
  hosts:
  - ips:
    - 172.16.26.165
    roles:
    - master
  image: localhost/abc:v1
  ssh:
    passwd: Seadent123
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
status: {}
---
kind: Application
metadata:
  name: my-apps
spec:
  launchApps:
    - shell
    - yamlapp
  configs:
    - name: yamlapp
      env:
        - gk2=testvalue
        - imageName=new-image-name-for-render
        - k2=v2
    - name: shell
      files:
        - path: rediscert
          strategy: "overwrite"
          data: |
            redis-user: root
            redis-passwd: xxx
```
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
