### PR TITLE
docs:Provide human-readable comment information

### DIFF
--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -102,6 +102,7 @@ func NewRunCmd() *cobra.Command {
 				Image:      args[0],
 				Platform:   "local",
 			})
+
 			if err != nil {
 				return err
 			}

--- a/cmd/sealer/cmd/cluster/run.go
+++ b/cmd/sealer/cmd/cluster/run.go
@@ -414,6 +414,7 @@ func runApplicationImage(request *RunApplicationImageRequest) error {
 	if err != nil {
 		return err
 	}
+	
 	infraDriver.AddClusterEnv(request.Envs)
 
 	if !request.SkipPrepareAppMaterials {

--- a/pkg/cluster-runtime/hook.go
+++ b/pkg/cluster-runtime/hook.go
@@ -103,7 +103,7 @@ func (r HookConfigList) Len() int           { return len(r) }
 func (r HookConfigList) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r HookConfigList) Less(i, j int) bool { return r[i].Name < r[j].Name }
 
-// runHostHook run host scope hook by Phase and only execute hook on the given host list.
+// runHostHook runs host scope hook by Phase and only executes hook on the given host list.
 func (i *Installer) runHostHook(phase Phase, hosts []net.IP) error {
 	hookConfigList, ok := i.hooks[phase]
 	if !ok {
@@ -218,6 +218,7 @@ func Register(name HookType, factory HookFunc) {
 	hookFactories[name] = factory
 }
 
+// transferPluginsToHooks transfer pluginConfig to hookConfig
 func transferPluginsToHooks(plugins []v1.Plugin) (map[Phase]HookConfigList, error) {
 	hooks := make(map[Phase]HookConfigList)
 

--- a/pkg/cluster-runtime/hook.go
+++ b/pkg/cluster-runtime/hook.go
@@ -50,22 +50,22 @@ const (
 	PreUnInstallCluster Phase = "pre-uninstall"
 	//PostUnInstallCluster on master0
 	PostUnInstallCluster Phase = "post-uninstall"
-	//PreScaleUpCluster on master0
+	//PreScaleUpCluster on master0: will run before scaleup cluster
 	PreScaleUpCluster Phase = "pre-scaleup"
-	//PostScaleUpCluster on master0
+	//PostScaleUpCluster on master0: will run after scaleup cluster
 	PostScaleUpCluster Phase = "post-scaleup"
-	//UpgradeHost on master0
+	//UpgradeHost on master0: will run for upgrading cluster 
 	UpgradeCluster Phase = "upgrade"
 
-	//PreInitHost on role
+	//PreInitHost on role: will run before init cluster host
 	PreInitHost Phase = "pre-init-host"
-	//PostInitHost on role
+	//PostInitHost on role: will run after init cluster host
 	PostInitHost Phase = "post-init-host"
-	//PreCleanHost on role
+	//PreCleanHost on role: will run before clean cluster host
 	PreCleanHost Phase = "pre-clean-host"
-	//PostCleanHost on role
+	//PostCleanHost on role: will run after clean cluster host
 	PostCleanHost Phase = "post-clean-host"
-	//UpgradeHost on role
+	//UpgradeHost on role: will run before upgrade cluster
 	UpgradeHost Phase = "upgrade-host"
 )
 

--- a/pkg/clusterfile/clusterfile.go
+++ b/pkg/clusterfile/clusterfile.go
@@ -144,6 +144,7 @@ func (c *ClusterFile) SaveAll(opts SaveOptions) error {
 		}
 		clusterfileBytes = append(clusterfileBytes, joinConfiguration)
 	}
+	
 	if len(c.kubeadmConfig.ClusterConfiguration.TypeMeta.Kind) != 0 {
 		clusterConfiguration, err := yaml.Marshal(c.kubeadmConfig.ClusterConfiguration)
 		if err != nil {

--- a/pkg/clusterfile/clusterfile_test.go
+++ b/pkg/clusterfile/clusterfile_test.go
@@ -20,12 +20,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
-
-	"github.com/sealerio/sealer/common"
+	"github.com/stretchr/testify/assert"
 )
 
 var defaultHA = true

--- a/pkg/runtime/kubernetes/kubeadm/kubeadm_config.go
+++ b/pkg/runtime/kubernetes/kubeadm/kubeadm_config.go
@@ -66,7 +66,7 @@ const (
 	KubeadmV1beta3 = "kubeadm.k8s.io/v1beta3"
 )
 
-// LoadFromClusterfile :Load KubeadmConfig from Clusterfile.
+// LoadFromClusterfile: Load KubeadmConfig from Clusterfile.
 // If it has `KubeadmConfig` in Clusterfile, load every field to each configuration.
 // If Kubeadm raw config in Clusterfile, just load it.
 func (k *KubeadmConfig) LoadFromClusterfile(kubeadmConfig KubeadmConfig) error {


### PR DESCRIPTION
Signed-off-by: Xinwei Xiong(cubxxw) <3293172751nss@gmail.com>
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.

-->

### Describe what this PR does / why we need it
sealer is the tool for building Kubernetes, and now sealer has a task that needs to turn localRegistry information into a secret in the namespace kube-system that some Kubernetes components can use.



### Does this pull request fix one issue?

fixes(teature): #2056

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->




### Describe how to verify it

You can obtain the localRegistry information from the 'Clusterfile' above using the following command:
```bash
 kubectl get secret -n kube-system ssealer-clusterfile-local-registry -oyaml
```
The output will include the name, namespace, label, and data of the secret. The output is rendered in YAML format due to the use of the '-oyaml' flag

### Special notes for reviews
@VinceCui 