### PR TITLE
bugfix: use registered app name as final app name list

### DIFF
--- a/pkg/application/v2app.go
+++ b/pkg/application/v2app.go
@@ -165,10 +165,13 @@ func NewV2Application(app *v2.Application, extension imagev1.ImageExtension) (In
 		app:                 app,
 		extension:           extension,
 		globalCmds:          extension.Launch.Cmds,
-		launchApps:          extension.Launch.AppNames,
 		appLaunchCmdsMap:    map[string][]string{},
 		appRootMap:          map[string]string{},
 		appFileProcessorMap: map[string][]FileProcessor{},
+	}
+
+	for _, registered := range extension.Applications {
+		v2App.launchApps = append(v2App.launchApps, registered.Name())
 	}
 
 	// initialize globalCmds, overwrite default cmds from image extension.


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Kuebfile:

```
FROM scratch
APP app1 local://app1.yaml
APP app2 local://app2.yaml
APP app3 local://app3.yaml
LAUNCH ["app1","app2"]
```

```yaml
apiVersion: sealer.io/v2
kind: Cluster
metadata:
  name: my-cluster
spec:
  hosts:
  - ips:
    - 172.16.26.168
    roles:
    - master
    ssh: {}
  image: myapp:v1
  appNames: ["app3"]
  ssh:
    passwd: xxxx
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
status: {}
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2166
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
