### PR TITLE
fix env bug

### DIFF
--- a/pkg/clusterfile/decoder.go
+++ b/pkg/clusterfile/decoder.go
@@ -230,8 +230,8 @@ func checkAndFillCluster(cluster *v2.Cluster) error {
 	cluster.Spec.Env = newEnv
 
 	clusterEnvMap := strUtil.ConvertStringSliceToMap(cluster.Spec.Env)
-	if svcCIDR, ok := clusterEnvMap[common.EnvSvcCIDR]; ok && svcCIDR != nil {
-		cidrs := strings.Split(svcCIDR.(string), ",")
+	if svcCIDR, ok := clusterEnvMap[common.EnvSvcCIDR]; ok && svcCIDR != "" {
+		cidrs := strings.Split(svcCIDR, ",")
 		_, cidr, err := net.ParseCIDR(cidrs[0])
 		if err != nil {
 			return fmt.Errorf("failed to parse svc CIDR: %v", err)

--- a/pkg/container-runtime/default.go
+++ b/pkg/container-runtime/default.go
@@ -24,7 +24,7 @@ import (
 
 type DefaultInstaller struct {
 	Info
-	envs   map[string]interface{}
+	envs   map[string]string
 	rootfs string
 	driver infradriver.InfraDriver
 }

--- a/pkg/container-runtime/installer.go
+++ b/pkg/container-runtime/installer.go
@@ -72,8 +72,8 @@ func NewInstaller(conf v2.ContainerRuntimeConfig, driver infradriver.InfraDriver
 			},
 		}
 		ret.Info.CgroupDriver = DefaultCgroupDriver
-		if cd, ok := ret.envs[CgroupDriverArg]; ok && cd != nil {
-			ret.Info.CgroupDriver = cd.(string)
+		if cd, ok := ret.envs[CgroupDriverArg]; ok && cd != "" {
+			ret.Info.CgroupDriver = cd
 		}
 
 		return ret, nil
@@ -89,8 +89,8 @@ func NewInstaller(conf v2.ContainerRuntimeConfig, driver infradriver.InfraDriver
 			},
 		}
 		ret.Info.CgroupDriver = DefaultCgroupDriver
-		if cd, ok := ret.envs[CgroupDriverArg]; ok && cd != nil {
-			ret.Info.CgroupDriver = cd.(string)
+		if cd, ok := ret.envs[CgroupDriverArg]; ok && cd != "" {
+			ret.Info.CgroupDriver = cd
 		}
 
 		return ret, nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -40,7 +40,7 @@ func base64decode(v string) string {
 
 // RenderTemplate :using renderData got from clusterfile to render all the files in dir with ".tmpl" as suffix.
 // The scope of renderData comes from cluster.spec.env
-func RenderTemplate(dir string, renderData map[string]interface{}) error {
+func RenderTemplate(dir string, renderData map[string]string) error {
 	return filepath.Walk(dir, func(path string, info os.FileInfo, errIn error) error {
 		if errIn != nil {
 			return errIn
@@ -75,7 +75,7 @@ func RenderTemplate(dir string, renderData map[string]interface{}) error {
 // Output shell: DATADISK=/data cat /etc/hosts
 // it is convenient for user to get env in scripts
 // The scope of env comes from cluster.spec.env and host.env
-func WrapperShell(shell string, wrapperData map[string]interface{}) string {
+func WrapperShell(shell string, wrapperData map[string]string) string {
 	env := getEnvFromData(wrapperData)
 
 	if len(env) == 0 {
@@ -84,15 +84,10 @@ func WrapperShell(shell string, wrapperData map[string]interface{}) string {
 	return fmt.Sprintf("%s %s", strings.Join(env, " "), shell)
 }
 
-func getEnvFromData(wrapperData map[string]interface{}) []string {
+func getEnvFromData(wrapperData map[string]string) []string {
 	var env []string
 	for k, v := range wrapperData {
-		switch value := v.(type) {
-		case []string:
-			env = append(env, fmt.Sprintf("export %s=(%s);", k, strings.Join(value, " ")))
-		case string:
-			env = append(env, fmt.Sprintf("export %s=\"%s\";", k, value))
-		}
+		env = append(env, fmt.Sprintf("export %s=\"%s\";", k, v))
 	}
 	sort.Strings(env)
 	return env

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -20,7 +20,7 @@ import (
 
 func Test_processor_WrapperShell(t *testing.T) {
 	type args struct {
-		wrapperData map[string]interface{}
+		wrapperData map[string]string
 		shell       string
 	}
 	tests := []struct {
@@ -31,7 +31,7 @@ func Test_processor_WrapperShell(t *testing.T) {
 		{
 			"test WrapperShell ",
 			args{
-				wrapperData: map[string]interface{}{
+				wrapperData: map[string]string{
 					"foo": "bar",
 					"IP":  "127.0.0.1",
 				},
@@ -51,7 +51,7 @@ func Test_processor_WrapperShell(t *testing.T) {
 
 func Test_processor_RenderAll(t *testing.T) {
 	type args struct {
-		renderData map[string]interface{}
+		renderData map[string]string
 		dir        string
 	}
 	tests := []struct {
@@ -62,7 +62,7 @@ func Test_processor_RenderAll(t *testing.T) {
 		{
 			"test render dir",
 			args{
-				renderData: map[string]interface{}{
+				renderData: map[string]string{
 					"PodCIDR": "100.64.0.0/10",
 					"SvcCIDR": "10.96.0.0/16",
 				},

--- a/pkg/infradriver/infradriver.go
+++ b/pkg/infradriver/infradriver.go
@@ -38,13 +38,13 @@ type InfraDriver interface {
 	GetHostsPlatform(hosts []net.IP) (map[v1.Platform][]net.IP, error)
 
 	//GetHostEnv return merged env with host env and cluster env.
-	GetHostEnv(host net.IP) map[string]interface{}
+	GetHostEnv(host net.IP) map[string]string
 
 	//GetHostLabels return host labels.
 	GetHostLabels(host net.IP) map[string]string
 
 	//GetClusterEnv return cluster.spec.env as map[string]interface{}
-	GetClusterEnv() map[string]interface{}
+	GetClusterEnv() map[string]string
 
 	AddClusterEnv(envs []string)
 
@@ -76,11 +76,11 @@ type InfraDriver interface {
 	// CopyR copy remote host files to localhost
 	CopyR(host net.IP, remoteFilePath, localFilePath string) error
 	// CmdAsync exec command on remote host, and asynchronous return logs
-	CmdAsync(host net.IP, env map[string]interface{}, cmd ...string) error
+	CmdAsync(host net.IP, env map[string]string, cmd ...string) error
 	// Cmd exec command on remote host, and return combined standard output and standard error
-	Cmd(host net.IP, env map[string]interface{}, cmd string) ([]byte, error)
+	Cmd(host net.IP, env map[string]string, cmd string) ([]byte, error)
 	// CmdToString exec command on remote host, and return spilt standard output and standard error
-	CmdToString(host net.IP, env map[string]interface{}, cmd, spilt string) (string, error)
+	CmdToString(host net.IP, env map[string]string, cmd, spilt string) (string, error)
 
 	// IsFileExist check remote file exist or not
 	IsFileExist(host net.IP, remoteFilePath string) (bool, error)

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -41,12 +41,12 @@ type SSHInfraDriver struct {
 	hostRolesMap map[string][]string
 	roleHostsMap map[string][]net.IP
 	hostLabels   map[string]map[string]string
-	hostEnvMap   map[string]map[string]interface{}
-	clusterEnv   map[string]interface{}
+	hostEnvMap   map[string]map[string]string
+	clusterEnv   map[string]string
 	cluster      v2.Cluster
 }
 
-func mergeList(hostEnv, globalEnv map[string]interface{}) map[string]interface{} {
+func mergeList(hostEnv, globalEnv map[string]string) map[string]string {
 	if len(hostEnv) == 0 {
 		return copyEnv(globalEnv)
 	}
@@ -71,11 +71,11 @@ func convertTaints(taints []string) ([]k8sv1.Taint, error) {
 	return k8staints, nil
 }
 
-func copyEnv(origin map[string]interface{}) map[string]interface{} {
+func copyEnv(origin map[string]string) map[string]string {
 	if origin == nil {
 		return nil
 	}
-	ret := make(map[string]interface{}, len(origin))
+	ret := make(map[string]string, len(origin))
 	for k, v := range origin {
 		ret[k] = v
 	}
@@ -92,7 +92,7 @@ func NewInfraDriver(cluster *v2.Cluster) (InfraDriver, error) {
 		roleHostsMap: map[string][]net.IP{},
 		hostRolesMap: map[string][]string{},
 		// todo need to separate env into app render data and sys render data
-		hostEnvMap: map[string]map[string]interface{}{},
+		hostEnvMap: map[string]map[string]string{},
 		hostLabels: map[string]map[string]string{},
 		hostTaint:  map[string][]k8sv1.Taint{},
 	}
@@ -177,7 +177,7 @@ func (d *SSHInfraDriver) GetRoleListByHostIP(ip string) []string {
 	return d.hostRolesMap[ip]
 }
 
-func (d *SSHInfraDriver) GetHostEnv(host net.IP) map[string]interface{} {
+func (d *SSHInfraDriver) GetHostEnv(host net.IP) map[string]string {
 	// Set env for each host
 	hostEnv := d.hostEnvMap[host.String()]
 	if _, ok := hostEnv[common.EnvHostIP]; !ok {
@@ -190,7 +190,7 @@ func (d *SSHInfraDriver) GetHostLabels(host net.IP) map[string]string {
 	return d.hostLabels[host.String()]
 }
 
-func (d *SSHInfraDriver) GetClusterEnv() map[string]interface{} {
+func (d *SSHInfraDriver) GetClusterEnv() map[string]string {
 	return d.clusterEnv
 }
 
@@ -225,7 +225,7 @@ func (d *SSHInfraDriver) CopyR(host net.IP, remoteFilePath, localFilePath string
 	return client.CopyR(host, localFilePath, remoteFilePath)
 }
 
-func (d *SSHInfraDriver) CmdAsync(host net.IP, env map[string]interface{}, cmd ...string) error {
+func (d *SSHInfraDriver) CmdAsync(host net.IP, env map[string]string, cmd ...string) error {
 	client := d.sshConfigs[host.String()]
 	if client == nil {
 		return fmt.Errorf("ip(%s) is not in cluster", host.String())
@@ -233,7 +233,7 @@ func (d *SSHInfraDriver) CmdAsync(host net.IP, env map[string]interface{}, cmd .
 	return client.CmdAsync(host, env, cmd...)
 }
 
-func (d *SSHInfraDriver) Cmd(host net.IP, env map[string]interface{}, cmd string) ([]byte, error) {
+func (d *SSHInfraDriver) Cmd(host net.IP, env map[string]string, cmd string) ([]byte, error) {
 	client := d.sshConfigs[host.String()]
 	if client == nil {
 		return nil, fmt.Errorf("ip(%s) is not in cluster", host.String())
@@ -241,7 +241,7 @@ func (d *SSHInfraDriver) Cmd(host net.IP, env map[string]interface{}, cmd string
 	return client.Cmd(host, env, cmd)
 }
 
-func (d *SSHInfraDriver) CmdToString(host net.IP, env map[string]interface{}, cmd, spilt string) (string, error) {
+func (d *SSHInfraDriver) CmdToString(host net.IP, env map[string]string, cmd, spilt string) (string, error) {
 	client := d.sshConfigs[host.String()]
 	if client == nil {
 		return "", fmt.Errorf("ip(%s) is not in cluster", host.String())

--- a/pkg/infradriver/ssh_infradriver_test.go
+++ b/pkg/infradriver/ssh_infradriver_test.go
@@ -28,7 +28,7 @@ func getDefaultCluster() (InfraDriver, error) {
 	cluster := &v2.Cluster{
 		Spec: v2.ClusterSpec{
 			Image: "kubernetes:v1.19.8",
-			Env:   []string{"key1=value1", "key2=value2;value3"},
+			Env:   []string{"key1=value1", "key2=value2, value3"},
 			SSH: v1.SSH{
 				User:     "root",
 				Passwd:   "test123",
@@ -86,22 +86,22 @@ func TestSSHInfraDriver_GetClusterInfo(t *testing.T) {
 		net.IPv4(192, 168, 0, 3),
 	})
 
-	assert.Equal(t, driver.GetClusterEnv(), map[string]interface{}{
+	assert.Equal(t, driver.GetClusterEnv(), map[string]string{
 		"key1": "value1",
-		"key2": []string{"value2", "value3"},
+		"key2": "value2, value3",
 	})
 
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]string{
 		"HostIP":   "192.168.0.2",
 		"key1":     "value1",
-		"key2":     []string{"value2", "value3"},
+		"key2":     "value2, value3",
 		"etcd-dir": "/data/etcd",
 	}, driver.GetHostEnv(net.IPv4(192, 168, 0, 2)))
 
-	assert.Equal(t, driver.GetHostEnv(net.IPv4(192, 168, 0, 3)), map[string]interface{}{
+	assert.Equal(t, driver.GetHostEnv(net.IPv4(192, 168, 0, 3)), map[string]string{
 		"HostIP":            "192.168.0.3",
 		"key1":              "value1",
-		"key2":              []string{"value2", "value3"},
+		"key2":              "value2, value3",
 		"test_node_env_key": "test_node_env_value",
 	})
 }

--- a/pkg/registry/local.go
+++ b/pkg/registry/local.go
@@ -170,11 +170,11 @@ func (c *localConfigurator) configureLvs(registryHosts, clientHosts []net.IP) er
 	}
 
 	if ipv4, ok := c.infraDriver.GetClusterEnv()[common.EnvIPvsVIPForIPv4]; ok {
-		vip = ipv4.(string)
+		vip = ipv4
 	}
 
 	if ipv6, ok := c.infraDriver.GetClusterEnv()[common.EnvIPvsVIPForIPv6]; ok {
-		vip = ipv6.(string)
+		vip = ipv6
 	}
 
 	vs := net.JoinHostPort(vip, strconv.Itoa(c.Port))

--- a/pkg/runtime/kubernetes/init.go
+++ b/pkg/runtime/kubernetes/init.go
@@ -36,8 +36,8 @@ import (
 func (k *Runtime) initKubeadmConfig(masters []net.IP) (kubeadm.KubeadmConfig, error) {
 	extraSANsStr := k.infra.GetClusterEnv()[common.EnvCertSANs]
 	var extraSANs []string
-	if extraSANsStr != nil && extraSANsStr.(string) != "" {
-		extraSANs = strings.Split(extraSANsStr.(string), ",")
+	if extraSANsStr != "" {
+		extraSANs = strings.Split(extraSANsStr, ",")
 	}
 	conf, err := kubeadm.NewKubeadmConfig(
 		k.Config.KubeadmConfigFromClusterFile,

--- a/pkg/runtime/kubernetes/runtime.go
+++ b/pkg/runtime/kubernetes/runtime.go
@@ -71,11 +71,11 @@ func NewKubeadmRuntime(clusterFileKubeConfig kubeadm.KubeadmConfig, infra infrad
 	}
 
 	if ipv4, ok := infra.GetClusterEnv()[common.EnvIPvsVIPForIPv4]; ok {
-		k.Config.VIP = ipv4.(string)
+		k.Config.VIP = ipv4
 	}
 
 	if ipv6, ok := infra.GetClusterEnv()[common.EnvIPvsVIPForIPv6]; ok {
-		k.Config.VIP = ipv6.(string)
+		k.Config.VIP = ipv6
 	}
 
 	if logrus.GetLevel() == logrus.DebugLevel {

--- a/pkg/runtime/kubernetes/utils.go
+++ b/pkg/runtime/kubernetes/utils.go
@@ -151,7 +151,7 @@ func (k *Runtime) Command(name CommandType, nodeNameOverride string) (string, er
 }
 
 func (k *Runtime) getNodeNameOverride(ip net.IP) string {
-	if v, ok := k.infra.GetClusterEnv()[common.EnvUseIPasNodeName]; ok && v.(string) == "true" {
+	if v, ok := k.infra.GetClusterEnv()[common.EnvUseIPasNodeName]; ok && v == "true" {
 		return ip.String()
 	}
 

--- a/utils/ssh/ssh.go
+++ b/utils/ssh/ssh.go
@@ -37,11 +37,11 @@ type Interface interface {
 	// CopyR copy remote host files to localhost
 	CopyR(host net.IP, srcFilePath, dstFilePath string) error
 	// CmdAsync exec command on remote host, and asynchronous return logs
-	CmdAsync(host net.IP, env map[string]interface{}, cmd ...string) error
+	CmdAsync(host net.IP, env map[string]string, cmd ...string) error
 	// Cmd exec command on remote host, and return combined standard output and standard error
-	Cmd(host net.IP, env map[string]interface{}, cmd string) ([]byte, error)
+	Cmd(host net.IP, env map[string]string, cmd string) ([]byte, error)
 	// CmdToString exec command on remote host, and return spilt standard output and standard error
-	CmdToString(host net.IP, env map[string]interface{}, cmd, spilt string) (string, error)
+	CmdToString(host net.IP, env map[string]string, cmd, spilt string) (string, error)
 	// IsFileExist check remote file exist or not
 	IsFileExist(host net.IP, remoteFilePath string) (bool, error)
 	// RemoteDirExist Remote file existence returns true, nil

--- a/utils/ssh/sshcmd.go
+++ b/utils/ssh/sshcmd.go
@@ -43,7 +43,7 @@ func (s *SSH) Ping(host net.IP) error {
 	return nil
 }
 
-func (s *SSH) CmdAsync(host net.IP, hostEnv map[string]interface{}, cmds ...string) error {
+func (s *SSH) CmdAsync(host net.IP, hostEnv map[string]string, cmds ...string) error {
 	var execFunc func(cmd string) error
 
 	if utilsnet.IsLocalIP(host, s.LocalAddress) {
@@ -120,7 +120,7 @@ func (s *SSH) CmdAsync(host net.IP, hostEnv map[string]interface{}, cmds ...stri
 	return nil
 }
 
-func (s *SSH) Cmd(host net.IP, hostEnv map[string]interface{}, cmd string) ([]byte, error) {
+func (s *SSH) Cmd(host net.IP, hostEnv map[string]string, cmd string) ([]byte, error) {
 	if s.User != common.ROOT {
 		cmd = fmt.Sprintf("sudo -E /bin/bash <<EOF\n%s\nEOF", cmd)
 	}
@@ -155,7 +155,7 @@ func (s *SSH) Cmd(host net.IP, hostEnv map[string]interface{}, cmd string) ([]by
 }
 
 // CmdToString is in host exec cmd and replace to spilt str
-func (s *SSH) CmdToString(host net.IP, env map[string]interface{}, cmd, split string) (string, error) {
+func (s *SSH) CmdToString(host net.IP, env map[string]string, cmd, split string) (string, error) {
 	data, err := s.Cmd(host, env, cmd)
 	str := string(data)
 	if err != nil {

--- a/utils/strings/strings.go
+++ b/utils/strings/strings.go
@@ -158,30 +158,18 @@ func Merge(ms ...[]string) []string {
 	return base
 }
 
-// ConvertStringSliceToMap Convert []string to map[string]interface{}
-func ConvertStringSliceToMap(stringSlice []string) (stringInterfaceMap map[string]interface{}) {
-	temp := make(map[string][]string)
-	stringInterfaceMap = make(map[string]interface{})
-
-	for _, e := range stringSlice {
-		var kv []string
-		if kv = strings.SplitN(e, "=", 2); len(kv) != 2 {
+// ConvertStringSliceToMap Convert []string to map[string]string
+func ConvertStringSliceToMap(stringSlice []string) (stringInterfaceMap map[string]string) {
+	ret := make(map[string]string, len(stringSlice))
+	for _, env := range stringSlice {
+		parsed := strings.SplitN(env, "=", 2)
+		if len(parsed) != 2 {
 			continue
 		}
-		temp[kv[0]] = append(temp[kv[0]], strings.Split(kv[1], ";")...)
+		ret[parsed[0]] = parsed[1]
 	}
 
-	for k, v := range temp {
-		if len(v) > 1 {
-			stringInterfaceMap[k] = v
-			continue
-		}
-		if len(v) == 1 {
-			stringInterfaceMap[k] = v[0]
-		}
-	}
-
-	return
+	return ret
 }
 
 func Diff(old, new []net.IP) (add, sub []net.IP) {

--- a/utils/strings/strings_test.go
+++ b/utils/strings/strings_test.go
@@ -24,7 +24,7 @@ import (
 func TestConvertEnv(t *testing.T) {
 	type args struct {
 		data   []string
-		wanted map[string]interface{}
+		wanted map[string]string
 	}
 
 	var tests = []struct {
@@ -34,9 +34,9 @@ func TestConvertEnv(t *testing.T) {
 		{
 			"test convert env",
 			args{
-				data: []string{"IP=127.0.0.1;192.168.0.2", "key=value"},
-				wanted: map[string]interface{}{
-					"IP":  []string{"127.0.0.1", "192.168.0.2"},
+				data: []string{"IP=127.0.0.1,192.168.0.2", "key=value"},
+				wanted: map[string]string{
+					"IP":  "127.0.0.1,192.168.0.2",
 					"key": "value",
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
```
[root@iZbp133pwc8drrt7ra1mkhZ ~]# cat .sealer/Clusterfile 
apiVersion: sealer.io/v2
kind: Cluster
metadata:
  name: my-cluster
spec:
  containerRuntime: {}
  env:
  - RegistryDomain=sea.hub
  - RegistryPort=5000
  - RegistryURL=sea.hub:5000
```

when dealing with `cluster.env` , convert string slice to map `map[string]string` instead of `map[string]interface{}`.
also, reslove value overwritten problem.

### Does this pull request fix one issue?
Fixes #2174
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
