### PR TITLE
feat: support pack different arch image together

### DIFF
--- a/build/kubefile/parser/image_engine_test.go
+++ b/build/kubefile/parser/image_engine_test.go
@@ -133,7 +133,7 @@ func (testImageEngine) PushManifest(name, destSpec string, opts *options.PushOpt
 	panic("implement me")
 }
 
-func (testImageEngine) AddToManifest(name, imageSpec string, opts *options.ManifestAddOpts) error {
+func (testImageEngine) AddToManifest(name string, imageSpec []string, opts *options.ManifestAddOpts) error {
 	panic("implement me")
 }
 

--- a/cmd/sealer/cmd/alpha/manifest.go
+++ b/cmd/sealer/cmd/alpha/manifest.go
@@ -101,23 +101,14 @@ func manifestAddCommand() *cobra.Command {
 		Long:  manifestAddDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				name, imageSpec string
+				manifestName = addManifestOpts.TargetName
+				imagesToAdd  = args
 			)
 
-			switch len(args) {
-			case 0, 1:
-				return errors.New("at least a manifest name and an image name to add must be specified")
-			case 2:
-				name = args[0]
-				if name == "" {
-					return fmt.Errorf(`invalid manifest name "%s" `, args[0])
-				}
-				imageSpec = args[1]
-				if imageSpec == "" {
-					return fmt.Errorf(`invalid image name "%s" `, args[1])
-				}
-			default:
-				return errors.New("at least two arguments are necessary: manifest name and an image name to add to list ")
+			// if not set `-t` flag , assume the first one is the manifestName,others is the images need to be added to.
+			if manifestName == "" {
+				manifestName = args[0]
+				imagesToAdd = args[1:]
 			}
 
 			engine, err := imageengine.NewImageEngine(options.EngineGlobalConfigurations{})
@@ -125,11 +116,11 @@ func manifestAddCommand() *cobra.Command {
 				return err
 			}
 
-			return engine.AddToManifest(name, imageSpec, &addManifestOpts)
+			return engine.AddToManifest(manifestName, imagesToAdd, &addManifestOpts)
 		},
-		Example: `sealer alpha manifest add mylist:v1.11 image:v1.11-amd64
-  sealer alpha manifest add mylist:v1.11 transport:imageName`,
-		Args: cobra.MinimumNArgs(2),
+		Example: `sealer alpha manifest add app-amd:v1 app-arm:v1 -t all-in-one:v1
+  sealer alpha manifest add mylist:v1.11 image:v1.11-amd64`,
+		Args: cobra.MinimumNArgs(1),
 	}
 
 	flags := addCommand.Flags()
@@ -140,6 +131,7 @@ func manifestAddCommand() *cobra.Command {
 	flags.StringSliceVar(&addManifestOpts.OsFeatures, "os-features", nil, "override the OS `features` of the specified image")
 	flags.StringSliceVar(&addManifestOpts.Annotations, "annotation", nil, "set an `annotation` for the specified image")
 	flags.BoolVar(&addManifestOpts.All, "all", false, "add all of the list's images if the image is a list")
+	flags.StringVarP(&addManifestOpts.TargetName, "target", "t", "", "target image name,if it is not exist,will create a new one")
 
 	return addCommand
 }

--- a/pkg/define/options/options.go
+++ b/pkg/define/options/options.go
@@ -187,6 +187,7 @@ type ManifestAddOpts struct {
 	OsFeatures  []string
 	Annotations []string
 	All         bool
+	TargetName  string
 }
 
 type ManifestRemoveOpts struct {

--- a/pkg/imageengine/buildah/load.go
+++ b/pkg/imageengine/buildah/load.go
@@ -127,21 +127,9 @@ func (engine *Engine) Load(opts *options.LoadOptions) error {
 		return fmt.Errorf("failed to create new manifest %s :%v ", manifestName, err)
 	}
 
-	defer func() {
-		if errors.Is(err, LoadError) {
-			err = engine.DeleteManifests([]string{manifestName}, &options.ManifestDeleteOpts{})
-			if err != nil {
-				logrus.Errorf("failed to delete manifest %s :%v ", manifestName, err)
-			}
-		}
-	}()
-
-	for _, imageID := range instancesIDs {
-		err = engine.AddToManifest(manifestName, imageID, &options.ManifestAddOpts{})
-		if err != nil {
-			logrus.Errorf("failed to add new image %s to %s :%v ", imageID, manifestName, err)
-			return LoadError
-		}
+	err = engine.AddToManifest(manifestName, instancesIDs, &options.ManifestAddOpts{})
+	if err != nil {
+		return fmt.Errorf("failed to add new image to %s :%v ", manifestName, err)
 	}
 
 	return nil

--- a/pkg/imageengine/interface.go
+++ b/pkg/imageengine/interface.go
@@ -69,7 +69,7 @@ type Interface interface {
 
 	PushManifest(name, destSpec string, opts *options.PushOptions) error
 
-	AddToManifest(name, imageSpec string, opts *options.ManifestAddOpts) error
+	AddToManifest(name string, imageNameOrIDList []string, opts *options.ManifestAddOpts) error
 
 	RemoveFromManifest(name string, instanceDigest digest.Digest, opts *options.ManifestRemoveOpts) error
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

1. support pack different arch image together

`sealer alpha manifest add amd:v1 arm:v1 -t all-in-one:v1`

`-t flag` : specify the wanted new image name, if null, will create a new one. if not null, it must be an existed manifest name.

`args`: if it is a single image just add it ,if it is a manifest will add it’s s all instance no matter what platform it is.


2. support save each manifest instance no-matter what platform it is.


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #2180
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
