### PR TITLE
feat: support merge cmd env with image extension

### DIFF
--- a/cmd/sealer/cmd/cluster/rollback.go
+++ b/cmd/sealer/cmd/cluster/rollback.go
@@ -114,7 +114,10 @@ func rollbackCluster(cf clusterfile.Interface, imageEngine imageengine.Interface
 	}
 
 	cluster := cf.GetCluster()
-	infraDriver, err := infradriver.NewInfraDriver(&cluster)
+	// merge image extension
+	mergedWithExt := utils.MergeClusterWithImageExtension(&cluster, imageSpec.ImageExtension)
+
+	infraDriver, err := infradriver.NewInfraDriver(mergedWithExt)
 	if err != nil {
 		return err
 	}
@@ -190,7 +193,7 @@ func rollbackCluster(cf clusterfile.Interface, imageEngine imageengine.Interface
 	appNames := infraDriver.GetClusterLaunchApps()
 
 	// merge to application between v2.ClusterSpec, v2.Application and image extension
-	v2App, err := application.NewV2Application(utils.ConstructApplication(cf.GetApplication(), cmds, appNames), imageSpec.ImageExtension)
+	v2App, err := application.NewV2Application(utils.ConstructApplication(cf.GetApplication(), cmds, appNames, cluster.Spec.Env), imageSpec.ImageExtension)
 	if err != nil {
 		return fmt.Errorf("failed to parse application from Clusterfile:%v ", err)
 	}

--- a/cmd/sealer/cmd/cluster/upgrade.go
+++ b/cmd/sealer/cmd/cluster/upgrade.go
@@ -122,7 +122,7 @@ func upgradeCluster(cf clusterfile.Interface, imageEngine imageengine.Interface,
 	}
 
 	cluster := cf.GetCluster()
-	infraDriver, err := infradriver.NewInfraDriver(&cluster)
+	infraDriver, err := infradriver.NewInfraDriver(utils.MergeClusterWithImageExtension(&cluster, imageSpec.ImageExtension))
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func upgradeCluster(cf clusterfile.Interface, imageEngine imageengine.Interface,
 	appNames := infraDriver.GetClusterLaunchApps()
 
 	// merge to application between v2.ClusterSpec, v2.Application and image extension
-	v2App, err := application.NewV2Application(utils.ConstructApplication(cf.GetApplication(), cmds, appNames), imageSpec.ImageExtension)
+	v2App, err := application.NewV2Application(utils.ConstructApplication(cf.GetApplication(), cmds, appNames, cluster.Spec.Env), imageSpec.ImageExtension)
 	if err != nil {
 		return fmt.Errorf("failed to parse application from Clusterfile:%v ", err)
 	}

--- a/cmd/sealer/cmd/utils/application.go
+++ b/cmd/sealer/cmd/utils/application.go
@@ -20,7 +20,7 @@ import (
 )
 
 //ConstructApplication merge flags to v2.Application
-func ConstructApplication(app *v2.Application, cmds, appNames, appEnvs []string) *v2.Application {
+func ConstructApplication(app *v2.Application, cmds, appNames, globalEnvs []string) *v2.Application {
 	var newApp *v2.Application
 
 	if app != nil {
@@ -43,10 +43,10 @@ func ConstructApplication(app *v2.Application, cmds, appNames, appEnvs []string)
 	}
 
 	// add appEnvs from flag to application object.
-	if len(appEnvs) > 0 {
+	if len(globalEnvs) > 0 {
 		var appConfigList []v2.ApplicationConfig
 		for _, appConfig := range newApp.Spec.Configs {
-			appConfig.Env = append(appEnvs, appConfig.Env...)
+			appConfig.Env = append(globalEnvs, appConfig.Env...)
 			appConfigList = append(appConfigList, appConfig)
 		}
 		newApp.Spec.Configs = appConfigList

--- a/cmd/sealer/cmd/utils/application.go
+++ b/cmd/sealer/cmd/utils/application.go
@@ -20,7 +20,7 @@ import (
 )
 
 //ConstructApplication merge flags to v2.Application
-func ConstructApplication(app *v2.Application, cmds, appNames []string) *v2.Application {
+func ConstructApplication(app *v2.Application, cmds, appNames, appEnvs []string) *v2.Application {
 	var newApp *v2.Application
 
 	if app != nil {
@@ -40,6 +40,16 @@ func ConstructApplication(app *v2.Application, cmds, appNames []string) *v2.Appl
 
 	if appNames != nil {
 		newApp.Spec.LaunchApps = appNames
+	}
+
+	// add appEnvs from flag to application object.
+	if len(appEnvs) > 0 {
+		var appConfigList []v2.ApplicationConfig
+		for _, appConfig := range newApp.Spec.Configs {
+			appConfig.Env = append(appEnvs, appConfig.Env...)
+			appConfigList = append(appConfigList, appConfig)
+		}
+		newApp.Spec.Configs = appConfigList
 	}
 
 	return newApp

--- a/cmd/sealer/cmd/utils/application_test.go
+++ b/cmd/sealer/cmd/utils/application_test.go
@@ -34,6 +34,9 @@ func getNewApp() *v2.Application {
 				"app1",
 				"app2",
 			},
+			Configs: []v2.ApplicationConfig{
+				{Env: []string{"Key=Value"}},
+			},
 		},
 	}
 	newApp.Name = "my-application"
@@ -60,6 +63,9 @@ func Test_ConstructApplication(t *testing.T) {
 				"app1",
 				"app2",
 			},
+			Configs: []v2.ApplicationConfig{
+				{Env: []string{"Key=Value"}},
+			},
 		},
 	}
 
@@ -79,6 +85,9 @@ func Test_ConstructApplication(t *testing.T) {
 			LaunchApps: []string{
 				"overwrite app1",
 				"overwrite app2",
+			},
+			Configs: []v2.ApplicationConfig{
+				{Env: []string{"Key=Value"}},
 			},
 		},
 	}
@@ -100,6 +109,32 @@ func Test_ConstructApplication(t *testing.T) {
 				"overwrite app1",
 				"overwrite app2",
 			},
+			Configs: []v2.ApplicationConfig{
+				{Env: []string{"Key=Value"}},
+			},
+		},
+	}
+
+	expectedAddAppEnvs := &v2.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: constants.ApplicationKind,
+			Kind:       v2.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-application",
+		},
+		Spec: v2.ApplicationSpec{
+			Cmds: []string{
+				"cmd 1",
+				"cmd 2",
+			},
+			LaunchApps: []string{
+				"app1",
+				"app2",
+			},
+			Configs: []v2.ApplicationConfig{
+				{Env: []string{"Key1=Value1", "Key=Value"}},
+			},
 		},
 	}
 
@@ -107,6 +142,7 @@ func Test_ConstructApplication(t *testing.T) {
 		name        string
 		cmds        []string
 		appNames    []string
+		appEnvs     []string
 		rawApp      *v2.Application
 		expectedApp *v2.Application
 	}{
@@ -122,7 +158,6 @@ func Test_ConstructApplication(t *testing.T) {
 			rawApp:      getNewApp(),
 			expectedApp: expectedOverwriteAppNames,
 		},
-
 		{
 			name:        "test overwrite app names and cmds",
 			cmds:        []string{"overwrite cmd 1", "overwrite cmd 2"},
@@ -130,11 +165,17 @@ func Test_ConstructApplication(t *testing.T) {
 			rawApp:      getNewApp(),
 			expectedApp: expectedOverwriteCmdsAndAppNames,
 		},
+		{
+			name:        "test add app envs",
+			appEnvs:     []string{"Key1=Value1"},
+			rawApp:      getNewApp(),
+			expectedApp: expectedAddAppEnvs,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expectedApp := ConstructApplication(tt.rawApp, tt.cmds, tt.appNames)
+			expectedApp := ConstructApplication(tt.rawApp, tt.cmds, tt.appNames, tt.appEnvs)
 			assert.Equal(t, expectedApp, tt.expectedApp)
 		})
 	}

--- a/cmd/sealer/cmd/utils/cluster.go
+++ b/cmd/sealer/cmd/utils/cluster.go
@@ -20,18 +20,30 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/sealerio/sealer/cmd/sealer/cmd/types"
 	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/client/k8s"
+	imagev1 "github.com/sealerio/sealer/pkg/define/image/v1"
 	"github.com/sealerio/sealer/types/api/constants"
 	v1 "github.com/sealerio/sealer/types/api/v1"
 	v2 "github.com/sealerio/sealer/types/api/v2"
+	"github.com/sealerio/sealer/utils/maps"
 	netutils "github.com/sealerio/sealer/utils/net"
 	strUtils "github.com/sealerio/sealer/utils/strings"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
+
+// MergeClusterWithImageExtension :set default value get from image extension,such as image global env
+func MergeClusterWithImageExtension(cluster *v2.Cluster, imageExt imagev1.ImageExtension) *v2.Cluster {
+	if len(imageExt.Env) > 0 {
+		envs := maps.ConvertToSlice(imageExt.Env)
+		envs = append(envs, cluster.Spec.Env...)
+		cluster.Spec.Env = envs
+	}
+
+	return cluster
+}
 
 func MergeClusterWithFlags(cluster v2.Cluster, mergeFlags *types.MergeFlags) (*v2.Cluster, error) {
 	if len(mergeFlags.CustomEnv) > 0 {

--- a/pkg/application/v2app.go
+++ b/pkg/application/v2app.go
@@ -22,14 +22,13 @@ import (
 	"strings"
 	"syscall"
 
-	mapUtils "github.com/sealerio/sealer/utils/maps"
-
 	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/pkg/define/application/v1"
 	imagev1 "github.com/sealerio/sealer/pkg/define/image/v1"
 	"github.com/sealerio/sealer/pkg/infradriver"
 	"github.com/sealerio/sealer/pkg/rootfs"
 	v2 "github.com/sealerio/sealer/types/api/v2"
+	mapUtils "github.com/sealerio/sealer/utils/maps"
 	strUtils "github.com/sealerio/sealer/utils/strings"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/application/v2app.go
+++ b/pkg/application/v2app.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"syscall"
 
+	mapUtils "github.com/sealerio/sealer/utils/maps"
+
 	"github.com/sealerio/sealer/common"
 	v1 "github.com/sealerio/sealer/pkg/define/application/v1"
 	imagev1 "github.com/sealerio/sealer/pkg/define/image/v1"
@@ -202,6 +204,8 @@ func NewV2Application(app *v2.Application, extension imagev1.ImageExtension) (In
 		appConfigFromImageMap[appConfig.Name] = appConfig
 	}
 
+	appEnvFromExtension := make(map[string]map[string]string)
+
 	for _, name := range v2App.launchApps {
 		appRoot := makeItDir(filepath.Join(rootfs.GlobalManager.App().Root(), name))
 		v2App.appRootMap[name] = appRoot
@@ -215,6 +219,7 @@ func NewV2Application(app *v2.Application, extension imagev1.ImageExtension) (In
 			} else {
 				v2App.appLaunchCmdsMap[name] = []string{v1app.LaunchCmd(appRoot, nil)}
 			}
+			appEnvFromExtension[name] = mapUtils.Merge(v1app.AppEnv, extension.Env)
 		}
 	}
 
@@ -239,7 +244,7 @@ func NewV2Application(app *v2.Application, extension imagev1.ImageExtension) (In
 		}
 
 		// add app env
-		v2App.appEnvMap[name] = strUtils.ConvertStringSliceToMap(config.Env)
+		v2App.appEnvMap[name] = mapUtils.Merge(strUtils.ConvertStringSliceToMap(config.Env), appEnvFromExtension[name])
 
 		// initialize app FileProcessors
 		var fileProcessors []FileProcessor


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

we have already supported set `ENV` and  `APPENV` on Kubefile, each key-pairs will be saved in image extension.see : https://github.com/sealerio/sealer/pull/2179.

so , how to use the default env with the user-defined env, That's what this PR does.

example:

Kubefile:

```shell
FROM scratch
ENV globalKey=globalValue
APP app1 local://app1
APP app2 local://app2
APP app3 local://app3
APPENV app1 key1=value1 key2=value2
LAUNCH ["app1","app2"]
```
 
1. merge  `ENV` value to  v2.ClusterSpec.Env, if not present, just append it.
2. merge `APPENV` value to v2.ApplicationConfig.Env, if not present, just append it.

priority order:

for cluster env:
user defined env from cmd flag  `-e` > v2.ClusterSpec.Env > ImageExtension.Env

for app env:

v2.ApplicationConfig.Env > v2.ClusterSpec.Env  > ImageExtension.Applications.Env


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
