### PR TITLE
feature: support run sealer image locally

### DIFF
--- a/cmd/sealer/cmd/types/types.go
+++ b/cmd/sealer/cmd/types/types.go
@@ -18,6 +18,7 @@ type RunFlags struct {
 	Masters string
 	Nodes   string
 
+	Provider		string
 	User        string
 	Password    string
 	Port        uint16


### PR DESCRIPTION
- command such as: `run my-cluster:v0.0`
- select the dockerfile according to the arch


### Describe what this PR does / why we need it
Use docker, implement support sealer run image locally, and no need to care about the underlying infrastructure

### Does this pull request fix one issue?
Fixes: #2087

### Describe how you did it
edit in cmd/sealer/cmd/cluster/run.go
  - mainly: `func runLocalWithDcoker()`

### Describe how to verify it
my bad, No sufficient test now. 
I want to know how to test my code(Specifically, which mirror should be used to test)

### Special notes for reviews
