### PR TITLE
feat: support to set sealer rootfs dir

### DIFF
--- a/pkg/clusterfile/clusterfile_test.go
+++ b/pkg/clusterfile/clusterfile_test.go
@@ -34,7 +34,8 @@ var defaultInsecure = false
 func TestSaveAll(t *testing.T) {
 	cluster := v2.Cluster{
 		Spec: v2.ClusterSpec{
-			Image: "kubernetes:v1.19.8",
+			Image:    "kubernetes:v1.19.8",
+			DataRoot: "/var/lib/sealer/data",
 			Env: []string{"key1=value1", "key2=value2;value3", "key=value",
 				"LocalRegistryDomain=sea.hub", "LocalRegistryPort=5000", "LocalRegistryURL=sea.hub:5000",
 				"RegistryDomain=sea.hub", "RegistryPort=5000", "RegistryURL=sea.hub:5000"},

--- a/pkg/clusterfile/decoder.go
+++ b/pkg/clusterfile/decoder.go
@@ -288,6 +288,10 @@ func checkAndFillCluster(cluster *v2.Cluster) error {
 		cluster.Spec.Env = append(cluster.Spec.Env, fmt.Sprintf("%s=%s", common.EnvContainerRuntime, cluster.Spec.ContainerRuntime.Type))
 	}
 
+	if cluster.Spec.DataRoot == "" {
+		cluster.Spec.DataRoot = common.DefaultSealerDataDir
+	}
+
 	return nil
 }
 

--- a/pkg/clusterfile/decoder_test.go
+++ b/pkg/clusterfile/decoder_test.go
@@ -117,8 +117,9 @@ ipvs:
 func TestDecodeClusterFile(t *testing.T) {
 	cluster := v2.Cluster{
 		Spec: v2.ClusterSpec{
-			Image: "kubernetes:v1.19.8",
-			Env:   []string{"key1=value1", "key2=value2;value3", "LocalRegistryDomain=sea.hub", "LocalRegistryPort=5000", "LocalRegistryURL=sea.hub:5000", "RegistryDomain=sea.hub", "RegistryPort=5000", "RegistryURL=sea.hub:5000"},
+			Image:    "kubernetes:v1.19.8",
+			DataRoot: "/var/lib/sealer/data",
+			Env:      []string{"key1=value1", "key2=value2;value3", "LocalRegistryDomain=sea.hub", "LocalRegistryPort=5000", "LocalRegistryURL=sea.hub:5000", "RegistryDomain=sea.hub", "RegistryPort=5000", "RegistryURL=sea.hub:5000"},
 			SSH: v1.SSH{
 				User:     "root",
 				Passwd:   "test123",

--- a/pkg/imageengine/buildah/save.go
+++ b/pkg/imageengine/buildah/save.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sealerio/sealer/common"
-
 	"github.com/containers/common/libimage"
 	"github.com/containers/common/libimage/manifests"
 	"github.com/pkg/errors"
+	"github.com/sealerio/sealer/common"
 	"github.com/sealerio/sealer/pkg/define/options"
 	"github.com/sealerio/sealer/utils/archive"
 	osi "github.com/sealerio/sealer/utils/os"

--- a/pkg/infradriver/ssh_infradriver.go
+++ b/pkg/infradriver/ssh_infradriver.go
@@ -338,11 +338,21 @@ func (d *SSHInfraDriver) GetHostsPlatform(hosts []net.IP) (map[v1.Platform][]net
 }
 
 func (d *SSHInfraDriver) GetClusterRootfsPath() string {
-	return filepath.Join(common.DefaultSealerDataDir, d.cluster.Name, "rootfs")
+	dataRoot := d.cluster.Spec.DataRoot
+	if dataRoot == "" {
+		dataRoot = common.DefaultSealerDataDir
+	}
+
+	return filepath.Join(dataRoot, d.cluster.Name, "rootfs")
 }
 
 func (d *SSHInfraDriver) GetClusterBasePath() string {
-	return filepath.Join(common.DefaultSealerDataDir, d.cluster.Name)
+	dataRoot := d.cluster.Spec.DataRoot
+	if dataRoot == "" {
+		dataRoot = common.DefaultSealerDataDir
+	}
+
+	return filepath.Join(dataRoot, d.cluster.Name)
 }
 
 func (d *SSHInfraDriver) Execute(hosts []net.IP, f func(host net.IP) error) error {

--- a/types/api/v2/cluster_types.go
+++ b/types/api/v2/cluster_types.go
@@ -49,6 +49,10 @@ type ClusterSpec struct {
 	HostAliases []HostAlias `json:"hostAliases,omitempty"`
 	// Registry field contains configurations about local registry and remote registry.
 	Registry Registry `json:"registry,omitempty"`
+
+	// DataRoot set sealer rootfs directory path.
+	// if not set, default value is "/var/lib/sealer/data"
+	DataRoot string `json:"dataRoot,omitempty"`
 }
 
 type ContainerRuntimeConfig struct {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

feat: support to set sealer rootfs dir via `v2.cluster.spec.DataRoot` , if not set will use `/var/lib/sealer/data` as default value. 

```yaml
apiVersion: sealer.io/v2
kind: Cluster
metadata:
  creationTimestamp: null
  name: my-cluster
spec:
  dataRoot: /tmp/kaka
  hosts:
  - ips:
    - 172.25.146.174
    roles:
    - master
    ssh: {}
  image: docker.io/sealerio/kubernetes:v1-22-15-sealerio-2
  ssh:
    passwd: xxxxx
    pk: /root/.ssh/id_rsa
    port: "22"
    user: root
status: {}

```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
