### PR TITLE
feat: sealer build supports lite mode option

### DIFF
--- a/pkg/define/options/options.go
+++ b/pkg/define/options/options.go
@@ -14,6 +14,16 @@
 
 package options
 
+const (
+	WithLiteMode = "lite"
+	WithAllMode  = "all"
+)
+
+var SupportedBuildModes = []string{
+	WithLiteMode,
+	WithAllMode,
+}
+
 // BuildOptions should be out of buildah scope.
 type BuildOptions struct {
 	Kubefile       string
@@ -32,6 +42,10 @@ type BuildOptions struct {
 	ImageList         string
 	ImageListWithAuth string
 	IgnoredImageList  string
+
+	//BuildMode means whether to download container image during the build process
+	// default value is download all container images.
+	BuildMode string
 }
 
 type FromOptions struct {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

In some case, some applications do not need to store additional container images. it is faster and smaller.

so, at build stage, sealer could try to skip download container image through build mode option.

if it is `lite`,  will skip download container image. default value is `all`, means download all container image.

how to use: 

```
sealer build -t abc:v1 --build-mode=lite
sealer build -t abc:v1 --build-mode=lite --platform linux/arm64
sealer build -t abc:v1 --build-mode=lite --platform linux/amd64,linux/arm64
```

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
